### PR TITLE
Update Simple Icons dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2452,9 +2452,9 @@
       "dev": true
     },
     "simple-icons": {
-      "version": "1.9.25",
-      "resolved": "https://registry.npmjs.org/simple-icons/-/simple-icons-1.9.25.tgz",
-      "integrity": "sha512-7/cNYsuuS82dcisAw4pSPu3aN7J9xiVoufhly3Pix6OND2DJIro8fGaODGCx4ssLCaylYgs8dZDCGft2ojFBJg==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/simple-icons/-/simple-icons-1.11.0.tgz",
+      "integrity": "sha512-0X+oHm3KvNybsYbrTlyrK2XDn0K+4sof6PIQaco1wt9y5Hkr6QA324YmMNrqRDgaOFoKfn9OX96vrXRf/RbbGQ==",
       "dev": true
     },
     "source-map": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
   "devDependencies": {
     "icon-font-buildr": "^1.3.3",
     "pug": "^2.0.3",
-    "simple-icons": "1.9.25"
+    "simple-icons": "^1.11.0"
   }
 }

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -8,6 +8,9 @@ const SimpleIcons = require('simple-icons'),
 // utils
 const { titleToFilename } = require('../lib/utils')
 
+// Exclude the Elsevier icon for now, it seems to be too big
+delete SimpleIcons['Elsevier'];
+
 // script
 const builder = new IconFontBuildr({
 	sources: [


### PR DESCRIPTION
Updates Simple Icons from v1.9.25 to v1.11.0

---

I had to remove the Elsevier logo from the font as it seems to be too large for fonts.`icon-font-buildr` gives the following ⬇️ error when building **with** the Elsevier logo.

```
events.js:167
      throw er; // Unhandled 'error' event
      ^

Error: Max buffer length exceeded: attribValue
Line: 0
Column: 130705
Char:
    at error (D:\Workspace\simple-icons-font\node_modules\sax\lib\sax.js:651:10)
    at checkBufferLength (D:\Workspace\simple-icons-font\node_modules\sax\lib\sax.js:125:13)
    at SAXParser.write (D:\Workspace\simple-icons-font\node_modules\sax\lib\sax.js:1505:7)
    at SAXStream.write (D:\Workspace\simple-icons-font\node_modules\sax\lib\sax.js:239:18)
    at ReadStream.ondata (_stream_readable.js:666:20)
    at ReadStream.emit (events.js:182:13)
    at addChunk (_stream_readable.js:283:12)
    at readableAddChunk (_stream_readable.js:264:11)
    at ReadStream.Readable.push (_stream_readable.js:219:10)
    at lazyFs.read (internal/fs/streams.js:181:12)
Emitted 'error' event at:
    at SAXStream.saxStream.on.err (D:\Workspace\simple-icons-font\node_modules\svgicons2svgfont\src\index.js:348:12)
    at SAXStream.emit (events.js:187:15)
    at SAXParser.SAXStream._parser.onerror (D:\Workspace\simple-icons-font\node_modules\sax\lib\sax.js:194:10)
    at emit (D:\Workspace\simple-icons-font\node_modules\sax\lib\sax.js:624:35)
    at error (D:\Workspace\simple-icons-font\node_modules\sax\lib\sax.js:653:5)
    at checkBufferLength (D:\Workspace\simple-icons-font\node_modules\sax\lib\sax.js:125:13)
    [... lines matching original stack trace ...]
    at ReadStream.emit (events.js:182:13)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
```