### PR TITLE
Update Simple Icons to v1.14.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2452,9 +2452,9 @@
       "dev": true
     },
     "simple-icons": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/simple-icons/-/simple-icons-1.13.0.tgz",
-      "integrity": "sha512-FjAph1Uf6q9mTp2/M16/8XjR0jHxZ/lrUHxnh6f3DsYtZiCO8jnD6LqPq3aidWS37rrLr6drWBLkZ7TVIHhGRA==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/simple-icons/-/simple-icons-1.14.0.tgz",
+      "integrity": "sha512-X8wH5bDrXHHM63JygweVpVfLNrhNPPNyWed68tvjllcvVlYmb39TgOgpblM5V7Lanzyq+4j9CinjzOJfdKe6tQ==",
       "dev": true
     },
     "source-map": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2452,10 +2452,9 @@
       "dev": true
     },
     "simple-icons": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/simple-icons/-/simple-icons-1.11.0.tgz",
-      "integrity": "sha512-0X+oHm3KvNybsYbrTlyrK2XDn0K+4sof6PIQaco1wt9y5Hkr6QA324YmMNrqRDgaOFoKfn9OX96vrXRf/RbbGQ==",
-      "dev": true
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/simple-icons/-/simple-icons-1.12.0.tgz",
+      "integrity": "sha512-mrqrsRrm3QZNiLKLCuhEwnMe8WHEyY5y2d/GbXMSBfnA73DUB2lEVXKkIZX+1gSuh0H31t59ORujknzhpEDH8A=="
     },
     "source-map": {
       "version": "0.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2452,9 +2452,10 @@
       "dev": true
     },
     "simple-icons": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/simple-icons/-/simple-icons-1.12.0.tgz",
-      "integrity": "sha512-mrqrsRrm3QZNiLKLCuhEwnMe8WHEyY5y2d/GbXMSBfnA73DUB2lEVXKkIZX+1gSuh0H31t59ORujknzhpEDH8A=="
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/simple-icons/-/simple-icons-1.13.0.tgz",
+      "integrity": "sha512-FjAph1Uf6q9mTp2/M16/8XjR0jHxZ/lrUHxnh6f3DsYtZiCO8jnD6LqPq3aidWS37rrLr6drWBLkZ7TVIHhGRA==",
+      "dev": true
     },
     "source-map": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
   "devDependencies": {
     "icon-font-buildr": "^1.3.3",
     "pug": "^2.0.3",
-    "simple-icons": "^1.11.0"
+    "simple-icons": "^1.12.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
   "devDependencies": {
     "icon-font-buildr": "^1.3.3",
     "pug": "^2.0.3",
-    "simple-icons": "^1.12.0"
+    "simple-icons": "^1.13.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
   "devDependencies": {
     "icon-font-buildr": "^1.3.3",
     "pug": "^2.0.3",
-    "simple-icons": "^1.13.0"
+    "simple-icons": "^1.14.0"
   }
 }

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -8,6 +8,9 @@ const SimpleIcons = require('simple-icons'),
 // utils
 const { titleToFilename } = require('../lib/utils')
 
+// Disable `.get` API function to allow simple iteration
+delete SimpleIcons.get
+
 // Exclude the Elsevier icon for now, it seems to be too big
 delete SimpleIcons['Elsevier'];
 

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -8,9 +8,6 @@ const SimpleIcons = require('simple-icons'),
 // utils
 const { titleToFilename } = require('../lib/utils')
 
-// Disable `.get` API function to allow simple iteration
-delete SimpleIcons.get
-
 // Exclude the Elsevier icon for now, it seems to be too big
 delete SimpleIcons['Elsevier'];
 


### PR DESCRIPTION
This Pull Request updates Simple Icons to the latest version. See https://github.com/simple-icons/simple-icons/pull/1549 for details.

Due to a change in the API I had to implement a bit of a hack to circumvent a problem with iterating over all the icons. ~~I will be addressing this issue up-stream 👍 EDIT: see https://github.com/simple-icons/simple-icons/issues/1554~~ This has been fixed and we should remove the hack when upgrading to the next version of Simple Icons.