### PR TITLE
Build in publish workflow using 'prepublishOnly' script

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,8 +17,6 @@ jobs:
         node-version: 12.x
     - name: Install dependencies
       run: npm ci
-    - name: Build font
-      run: npm run build
     - name: Deploy to NPM
       uses: JS-DevTools/npm-publish@v1
       with:


### PR DESCRIPTION
The build process it's executed 2 times in publish workflow, one explicitly and implicitly with `prepublishOnly` script.
I've removed the explicit step in this pull. Other option is to remove the `prepublishOnly` script.