### PR TITLE
Add setup and usage documentation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,20 +7,70 @@
 Free SVG icon font for popular brands. See them all on one page at <a href="https://simpleicons.org">SimpleIcons.org</a>. Contributions, corrections & requests can be made on GitHub. Started by <a href="https://twitter.com/bathtype">Dan Leech</a>.</p>
 </p>
 
-## Usage
+## Setup
 
-### General Usage
+### From CDN
 
-This package can be installed into your project with NPM to provide all of our icons as an icon font.
+```html
+<html>
+  <head>
+    <meta charset="utf-8">
+    <link rel="stylesheet"
+          href="https://cdn.jsdelivr.net/npm/simple-icons-font/font/simple-icons.min.css"
+          type="text/css">
+  </head>
+  <body>
+    <i class="simpleicons simpleicons-simpleicons simpleicons--color"></i>
+  </body>
+</html>
+```
 
-```bash
+### Manual download
+
+1. Download the latest version of the package from
+[here][npm-registry-tarball-link], extract it and move the content of the
+`font` folder to your desired location. 
+1. Reference the CSS file in a `link` tag of your HTML:
+
+```html
+<html>
+  <head>
+    <meta charset="utf-8">
+    <link rel="stylesheet" href="simple-icons.min.css" type="text/css">
+  </head>
+  <body>
+    <i class="simpleicons simpleicons-simpleicons simpleicons--color"></i>
+  </body>
+</html>
+```
+
+### Using module bundlers
+
+```
 npm install simple-icons-font
 ```
 
-After installation, the icon font can then be found in `node_modules/simple-icons-font/font` along with a stylesheet for
-a basic setup.
+After installation, the icon font can then be found in
+`node_modules/simple-icons-font/font` along with stylesheets for a basic setup.
+
+## Usage
+
+The CSS files of simple-icons-font contains next classes:
+
+- `simpleicons`: Adds the font to the container that will display the icon.
+- `simpleicons--color`: Colorizes the icon with the main color of the brand.
+- `simpleicons-<ICON SLUG>`: Replace here `<ICON SLUG>` by with the
+ correspondent slug for the icon. Their slugs correpond to filenames, which you
+ can see listed [here][simple-icons--icons-dir-link]. 
 
 ## Status
 
-[![Build Status](https://github.com/simple-icons/simple-icons-font/workflows/Verify/badge.svg)](https://github.com/simple-icons/simple-icons-font/actions?query=workflow%3AVerify+branch%3Adevelop)
-[![npm version](https://img.shields.io/npm/v/simple-icons-font.svg)](https://www.npmjs.com/package/simple-icons-font)
+[![Build Status][build-status-image]][build-status-link]
+[![NPM version][npm-version-image]][npm-package-link]
+
+[build-status-image]: https://img.shields.io/github/workflow/status/simple-icons/simple-icons-font/Verify/develop?logo=github
+[build-status-link]: https://github.com/simple-icons/simple-icons-font/actions?query=workflow%3AVerify+branch%3Adevelop
+[npm-version-image]: https://img.shields.io/npm/v/simple-icons-font?logo=npm
+[npm-package-link]: https://www.npmjs.com/package/simple-icons-font
+[simple-icons--icons-dir-link]: https://github.com/simple-icons/simple-icons/tree/develop/icons
+[npm-registry-tarball-link]: https://registry.npmjs.org/simple-icons-font/-/simple-icons-font-2.0.0.tgz

--- a/README.md
+++ b/README.md
@@ -31,14 +31,11 @@ Free SVG icon font for popular brands. See them all on one page at <a href="http
 npm install simple-icons-font
 ```
 
-After installation, the icon font can then be found in
-`node_modules/simple-icons-font/font` along with stylesheets for a basic setup.
+After installation, the icon font can then be found in `node_modules/simple-icons-font/font` along with stylesheets for a basic setup.
 
 ### Manual download
 
-1. Download the latest version of the package from
-[here][npm-registry-tarball-link], extract it and move the content of the
-`font` folder to your desired location. 
+1. Download the latest version of the package from [here][npm-registry-tarball-link], extract it and move the content of the `font` folder to your desired location. 
 1. Reference the CSS file in a `link` tag of your HTML:
 
 ```html
@@ -59,9 +56,7 @@ The CSS files of simple-icons-font contains next classes:
 
 - `simpleicons`: Adds the font to the container that will display the icon.
 - `simpleicons--color`: Colorizes the icon with the main color of the brand.
-- `simpleicons-<ICON SLUG>`: Replace here `<ICON SLUG>` by with the
- correspondent slug for the icon. Their slugs correpond to filenames, which you
- can see listed [here][simple-icons--icons-dir-link]. 
+- `simpleicons-[ICON SLUG]`: Replace here `[ICON SLUG]` by with the correspondent slug for the icon. Their slugs correpond to filenames, which you can see listed [here][simple-icons--icons-dir-link].
 
 ## Status
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Free SVG icon font for popular brands. See them all on one page at <a href="http
 
 ## Setup
 
-### From CDN
+### CDN
 
 The font can be served from a CDN such as [JSDelivr][jsdelivr-link] or [Unpkg][unpkg-link]. Simply use the `simple-icons-font` NPM package and specify a version in the URL like the following:
 
@@ -18,7 +18,7 @@ The font can be served from a CDN such as [JSDelivr][jsdelivr-link] or [Unpkg][u
 <link rel="stylesheet" href="https://unpkg.com/simple-icons-font@2/font/simple-icons.min.css" type="text/css">
 ```
 
-These examples use the latest major version. This means you won't receive any updates following the next major release. You can use `@latest` instead to receive updates indefinitely. However, this will result in icons not showing as expected if an icon is removed.
+These examples use the latest major version. This means you won't receive any updates following the next major release. You can use `@latest` instead to receive updates indefinitely. However this may cause an icon to disappear if it has been removed in the latest version.
 
 ### NodeJS
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Free SVG icon font for popular brands. See them all on one page at <a href="http
 ### Using module bundlers
 
 ```
-npm install simple-icons-font
+$ npm install simple-icons-font
 ```
 
 After installation, the icon font can then be found in `node_modules/simple-icons-font/font` along with stylesheets for a basic setup.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ The font can be served from a CDN such as [JSDelivr][jsdelivr-link] or [Unpkg][u
 <link rel="stylesheet" href="https://unpkg.com/simple-icons-font@2/font/simple-icons.min.css" type="text/css">
 ```
 
+These examples use the latest major version. This means you won't receive any updates following the next major release. You can use `@latest` instead to receive updates indefinitely. However, this will result in a icons not showing as expected if an icon is removed.
+
 ### NodeJS
 
 The font is also available through our npm package. To install, simply run:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The font can be served from a CDN such as [JSDelivr][jsdelivr-link] or [Unpkg][u
 <link rel="stylesheet" href="https://unpkg.com/simple-icons-font@2/font/simple-icons.min.css" type="text/css">
 ```
 
-These examples use the latest major version. This means you won't receive any updates following the next major release. You can use `@latest` instead to receive updates indefinitely. However, this will result in a icons not showing as expected if an icon is removed.
+These examples use the latest major version. This means you won't receive any updates following the next major release. You can use `@latest` instead to receive updates indefinitely. However, this will result in icons not showing as expected if an icon is removed.
 
 ### NodeJS
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The font can be served from a CDN such as [JSDelivr][jsdelivr-link] or [Unpkg][u
 
 These examples use the latest major version. This means you won't receive any updates following the next major release. You can use `@latest` instead to receive updates indefinitely. However this may cause an icon to disappear if it has been removed in the latest version.
 
-### NodeJS Setup
+### Node Setup
 
 The font is also available through our npm package. To install, simply run:
 

--- a/README.md
+++ b/README.md
@@ -11,13 +11,10 @@ Free SVG icon font for popular brands. See them all on one page at <a href="http
 
 ### From CDN
 
-The font can be served from a CDN such as [JSDelivr][jsdelivr-link] or [Unpkg][unkpkg-link]. Simply use the `simple-icons-font` npm package and specify a version in the URL like the following:
+The font can be served from a CDN such as [JSDelivr][jsdelivr-link] or [Unpkg][unpkg-link]. Simply use the `simple-icons-font` NPM package and specify a version in the URL like the following:
 
 ```html
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/simple-icons-font@v2/font/simple-icons.min.css" type="text/css">
-```
-
-```html
 <link rel="stylesheet" href="https://unpkg.com/simple-icons-font@2/font/simple-icons.min.css" type="text/css">
 ```
 
@@ -29,7 +26,7 @@ The font is also available through our npm package. To install, simply run:
 $ npm install simple-icons-font
 ```
 
-After installation, the icon and stylesheet font can then be found in `node_modules/simple-icons-font/font`. You can use your favorite bundling tools to include them into your project.
+After installation, the icons font and stylesheet font can then be found in `node_modules/simple-icons-font/font`. You can use your favorite bundling tool to include them into your project.
 
 ### Manual download
 
@@ -57,11 +54,6 @@ Where `[ICON NAME]` is replaced by the icon name, for example:
 
 In this example we use the `<i>` tag, but any inline HTML tag should work as you expect.
 
-### Example
-
-```html
-<i class="simpleicons simpleicons--color simpleicons-simpleicons"></i>
-```
 
 ## Status
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ The font can be served from a CDN such as [JSDelivr][jsdelivr-link] or [Unpkg][u
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/simple-icons-font@v2/font/simple-icons.min.css" type="text/css">
 ```
 
+```html
+<link rel="stylesheet" href="https://unpkg.com/simple-icons-font@2/font/simple-icons.min.css" type="text/css">
+```
+
 ### NodeJS
 
 The font is also available through our npm package. To install, simply run:

--- a/README.md
+++ b/README.md
@@ -12,20 +12,12 @@ Free SVG icon font for popular brands. See them all on one page at <a href="http
 ### From CDN
 
 ```html
-<html>
-  <head>
-    <meta charset="utf-8">
-    <link rel="stylesheet"
-          href="https://cdn.jsdelivr.net/npm/simple-icons-font/font/simple-icons.min.css"
-          type="text/css">
-  </head>
-  <body>
-    <i class="simpleicons simpleicons-simpleicons simpleicons--color"></i>
-  </body>
-</html>
+<link rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/simple-icons-font/font/simple-icons.min.css"
+      type="text/css">
 ```
 
-### Using module bundlers
+### NodeJS
 
 ```
 $ npm install simple-icons-font
@@ -39,15 +31,9 @@ After installation, the icon font can then be found in `node_modules/simple-icon
 1. Reference the CSS file in a `link` tag of your HTML:
 
 ```html
-<html>
-  <head>
-    <meta charset="utf-8">
-    <link rel="stylesheet" href="simple-icons.min.css" type="text/css">
-  </head>
-  <body>
-    <i class="simpleicons simpleicons-simpleicons simpleicons--color"></i>
-  </body>
-</html>
+<link rel="stylesheet"
+      href="/path/to/simple-icons.min.css"
+      type="text/css">
 ```
 
 ## Usage
@@ -56,7 +42,13 @@ The CSS files of simple-icons-font contains next classes:
 
 - `simpleicons`: Adds the font to the container that will display the icon.
 - `simpleicons--color`: Colorizes the icon with the main color of the brand.
-- `simpleicons-[ICON SLUG]`: Replace here `[ICON SLUG]` by with the correspondent slug for the icon. Their slugs correpond to filenames, which you can see listed [here][simple-icons--icons-dir-link].
+- `simpleicons-[ICON SLUG]`: Replace here `[ICON SLUG]` by with the correspondent slug for the icon. Their slugs correpond to filenames, which you can see listed in [simple-icons/icons][simple-icons--icons-dir-link].
+
+### Example
+
+```html
+<i class="simpleicons simpleicons--color simpleicons-simpleicons"></i>
+```
 
 ## Status
 

--- a/README.md
+++ b/README.md
@@ -11,38 +11,47 @@ Free SVG icon font for popular brands. See them all on one page at <a href="http
 
 ### From CDN
 
+The font can be served from a CDN such as [JSDelivr][jsdelivr-link] or [Unpkg][unkpkg-link]. Simply use the `simple-icons-font` npm package and specify a version in the URL like the following:
+
 ```html
-<link rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/simple-icons-font@v2/font/simple-icons.min.css"
-      type="text/css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/simple-icons-font@v2/font/simple-icons.min.css" type="text/css">
 ```
 
 ### NodeJS
+
+The font is also available through our npm package. To install, simply run:
 
 ```
 $ npm install simple-icons-font
 ```
 
-After installation, the icon font can then be found in `node_modules/simple-icons-font/font` along with stylesheets for a basic setup.
+After installation, the icon and stylesheet font can then be found in `node_modules/simple-icons-font/font`. You can use your favorite bundling tools to include them into your project.
 
 ### Manual download
 
-1. [Download the latest version of the package][npm-registry-tarball-link], extract it, and move the content of the `font` folder to your desired location.
-1. Reference the CSS file in a `link` tag of your HTML:
+You can also [download the latest version of the package][npm-registry-tarball-link] and copy the content of the `font` folder into your project. Then, reference the CSS file using a `link` tag in your HTML:
 
 ```html
-<link rel="stylesheet"
-      href="/path/to/simple-icons.min.css"
-      type="text/css">
+<link rel="stylesheet" href="/path/to/simple-icons.min.css" type="text/css">
 ```
 
 ## Usage
 
-The CSS files of simple-icons-font contains next classes:
+Use any of the icons available in simple-icons by adding the following classes to a node in your HTML. Use the `simple-icons--color` class to apply the brand's color to the icon.
 
-- `simpleicons`: Adds the font to the container that will display the icon.
-- `simpleicons--color`: Colorizes the icon with the main color of the brand.
-- `simpleicons-[ICON SLUG]`: Replace here `[ICON SLUG]` by with the correspondent slug for the icon. Their slugs correpond to filenames, which you can see listed in [simple-icons/icons][simple-icons--icons-dir-link].
+```html
+<i class="simpleicons simpleicons-[ICON NAME]"></i>
+<i class="simpleicons simpleicons-[ICON NAME] simple-icons--color"></i>
+```
+
+Where `[ICON NAME]` is replaced by the icon name, for example:
+
+```html
+<i class="simpleicons simpleicons-simpleicons"></i>
+<i class="simpleicons simpleicons-simpleicons simple-icons--color"></i>
+```
+
+In this example we use the `<i>` tag, but any inline HTML tag should work as you expect.
 
 ### Example
 
@@ -59,5 +68,6 @@ The CSS files of simple-icons-font contains next classes:
 [build-status-link]: https://github.com/simple-icons/simple-icons-font/actions?query=workflow%3AVerify+branch%3Adevelop
 [npm-version-image]: https://img.shields.io/npm/v/simple-icons-font?logo=npm
 [npm-package-link]: https://www.npmjs.com/package/simple-icons-font
-[simple-icons--icons-dir-link]: https://github.com/simple-icons/simple-icons/tree/develop/icons
 [npm-registry-tarball-link]: https://registry.npmjs.org/simple-icons-font/-/simple-icons-font-2.0.0.tgz
+[jsdelivr-link]: https://www.jsdelivr.com/package/npm/simple-icons-font/
+[unpkg-link]: https://unpkg.com/browse/simple-icons-font/

--- a/README.md
+++ b/README.md
@@ -25,6 +25,15 @@ Free SVG icon font for popular brands. See them all on one page at <a href="http
 </html>
 ```
 
+### Using module bundlers
+
+```
+npm install simple-icons-font
+```
+
+After installation, the icon font can then be found in
+`node_modules/simple-icons-font/font` along with stylesheets for a basic setup.
+
 ### Manual download
 
 1. Download the latest version of the package from
@@ -43,15 +52,6 @@ Free SVG icon font for popular brands. See them all on one page at <a href="http
   </body>
 </html>
 ```
-
-### Using module bundlers
-
-```
-npm install simple-icons-font
-```
-
-After installation, the icon font can then be found in
-`node_modules/simple-icons-font/font` along with stylesheets for a basic setup.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Free SVG icon font for popular brands. See them all on one page at <a href="http
 
 ```html
 <link rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/simple-icons-font/font/simple-icons.min.css"
+      href="https://cdn.jsdelivr.net/npm/simple-icons-font@v2/font/simple-icons.min.css"
       type="text/css">
 ```
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Free SVG icon font for popular brands. See them all on one page at <a href="http
 
 ## Setup
 
-### CDN
+### CDN Setup
 
 The font can be served from a CDN such as [JSDelivr][jsdelivr-link] or [Unpkg][unpkg-link]. Simply use the `simple-icons-font` NPM package and specify a version in the URL like the following:
 
@@ -20,7 +20,7 @@ The font can be served from a CDN such as [JSDelivr][jsdelivr-link] or [Unpkg][u
 
 These examples use the latest major version. This means you won't receive any updates following the next major release. You can use `@latest` instead to receive updates indefinitely. However this may cause an icon to disappear if it has been removed in the latest version.
 
-### NodeJS
+### NodeJS Setup
 
 The font is also available through our npm package. To install, simply run:
 
@@ -30,7 +30,7 @@ $ npm install simple-icons-font
 
 After installation, the icons font and stylesheet font can be found in `node_modules/simple-icons-font/font`. You can use your favorite bundling tool to include them into your project.
 
-### Manual download
+### Manual Setup
 
 You can also [download the latest version of the package][npm-registry-tarball-link] and copy the content of the `font` folder into your project. Then, reference the CSS file using a `link` tag in your HTML:
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The font is also available through our npm package. To install, simply run:
 $ npm install simple-icons-font
 ```
 
-After installation, the icons font and stylesheet font can then be found in `node_modules/simple-icons-font/font`. You can use your favorite bundling tool to include them into your project.
+After installation, the icons font and stylesheet font can be found in `node_modules/simple-icons-font/font`. You can use your favorite bundling tool to include them into your project.
 
 ### Manual download
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ After installation, the icon font can then be found in `node_modules/simple-icon
 
 ### Manual download
 
-1. Download the latest version of the package from [here][npm-registry-tarball-link], extract it and move the content of the `font` folder to your desired location. 
+1. [Download the latest version of the package][npm-registry-tarball-link], extract it, and move the content of the `font` folder to your desired location.
 1. Reference the CSS file in a `link` tag of your HTML:
 
 ```html


### PR DESCRIPTION
Closes #5

- Setup instructions with example using the font from CDN.
- Setup instructions with example downloading the font from NPM registry. The URL has the version hardcoded, this must be updated by release process or find a way to reference the latest version.
- Installation for module bundlers.
- Basic description of CSS classes.
- Improved badges images and README Markdown markup.