### PR TITLE
Set up automated GitHub releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,3 +21,28 @@ jobs:
       uses: JS-DevTools/npm-publish@v1
       with:
         token: ${{ secrets.NPM_TOKEN }}
+  github:
+    name: GitHub release
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Get release version
+      id: get_version
+      run: |
+        export PACKAGE_VERSION=$(cat package.json | grep 'version' | sed 's/[ \",:]//g' | sed 's/version//')
+        echo "::set-output name=version::$PACKAGE_VERSION"
+    - name: Create and push git tag
+      uses: actions-ecosystem/action-push-tag@v1
+      with:
+        tag: ${{ steps.get_version.outputs.version }}
+        message: ${{ steps.commit.outputs.git-message }}
+    - name: Create release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ steps.get_version.outputs.version }}
+        release_name: Release ${{ steps.get_version.outputs.version }}
+        draft: false
+        prerelease: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,5 +44,3 @@ jobs:
       with:
         tag_name: ${{ steps.get-version.outputs.version }}
         release_name: Release ${{ steps.get-version.outputs.version }}
-        draft: false
-        prerelease: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,21 +28,21 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Get release version
-      id: get_version
+      id: get-version
       run: |
         export PACKAGE_VERSION=$(cat package.json | grep 'version' | sed 's/[ \",:]//g' | sed 's/version//')
         echo "::set-output name=version::$PACKAGE_VERSION"
     - name: Create and push git tag
       uses: actions-ecosystem/action-push-tag@v1
       with:
-        tag: ${{ steps.get_version.outputs.version }}
+        tag: ${{ steps.get-version.outputs.version }}
         message: ${{ steps.commit.outputs.git-message }}
     - name: Create release
       uses: actions/create-release@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        tag_name: ${{ steps.get_version.outputs.version }}
-        release_name: Release ${{ steps.get_version.outputs.version }}
+        tag_name: ${{ steps.get-version.outputs.version }}
+        release_name: Release ${{ steps.get-version.outputs.version }}
         draft: false
         prerelease: false

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ After installation, the icons font and stylesheet font can be found in `node_mod
 
 ### Manual Setup
 
-You can also [download the latest version of the package][npm-registry-tarball-link] and copy the content of the `font` folder into your project. Then, reference the CSS file using a `link` tag in your HTML:
+You can also [download the latest version of the package][latest-release] and copy the content of the `font` folder into your project. Then, reference the CSS file using a `link` tag in your HTML:
 
 ```html
 <link rel="stylesheet" href="/path/to/simple-icons.min.css" type="text/css">
@@ -66,6 +66,6 @@ In this example we use the `<i>` tag, but any inline HTML tag should work as you
 [build-status-link]: https://github.com/simple-icons/simple-icons-font/actions?query=workflow%3AVerify+branch%3Adevelop
 [npm-version-image]: https://img.shields.io/npm/v/simple-icons-font?logo=npm
 [npm-package-link]: https://www.npmjs.com/package/simple-icons-font
-[npm-registry-tarball-link]: https://registry.npmjs.org/simple-icons-font/-/simple-icons-font-2.0.0.tgz
+[latest-release]: https://github.com/simple-icons/simple-icons-font/releases/latest
 [jsdelivr-link]: https://www.jsdelivr.com/package/npm/simple-icons-font/
 [unpkg-link]: https://unpkg.com/browse/simple-icons-font/


### PR DESCRIPTION
As per https://github.com/simple-icons/simple-icons-font/pull/53#discussion_r544604289, this updates the `publish.yml` workflow to automatically create git tags and GitHub Releases for every release. The configuration is based on [the same job for the main repo](https://github.com/simple-icons/simple-icons/blob/c6044cf0c74a6e5a9a92dac3c426c5643b5790d4/.github/workflows/publish.yml#L28-L73), but slightly simplified as I didn't try to come up with a fancy release title or body. I'd say, if we want, we can come up with some content for the release later.