### PR TITLE
Update simple-icons dependency to v2.19.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1602,9 +1602,9 @@
       "dev": true
     },
     "simple-icons": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/simple-icons/-/simple-icons-2.3.0.tgz",
-      "integrity": "sha512-K8oNTa1TDC6CFR5UqnWjeLNawsUbFT1WRlHLvwC8Bz8UwD+KCaHpFxr3X7fw35TZ784D3WPn9FhaYld443qaZQ==",
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/simple-icons/-/simple-icons-2.19.0.tgz",
+      "integrity": "sha512-DI0ZIKGoZlEnGqPF5jIGaOWWDvcXL323SZc7JBQp+pT/k0p72GU9Vxy7+UEtU9zZfWTbKiSQgtERF3pzPFhV2A==",
       "dev": true
     },
     "source-map": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "pug": "3.0.0",
     "punycode": "2.1.1",
     "puppeteer": "5.5.0",
-    "simple-icons": "2.3.0",
+    "simple-icons": "2.19.0",
     "svg2ttf": "5.0.0",
     "svgpath": "2.3.0",
     "ttf2woff": "2.0.2",


### PR DESCRIPTION
Following the planning discussed in #50 this is in preparation of the next release, v2.19.0, which will match [simple-icons@2.19.0](https://www.npmjs.com/package/simple-icons/v/2.19.0).