### PR TITLE
Update simple-icons dependency to v3.13.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1602,9 +1602,9 @@
       "dev": true
     },
     "simple-icons": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/simple-icons/-/simple-icons-2.19.0.tgz",
-      "integrity": "sha512-DI0ZIKGoZlEnGqPF5jIGaOWWDvcXL323SZc7JBQp+pT/k0p72GU9Vxy7+UEtU9zZfWTbKiSQgtERF3pzPFhV2A==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/simple-icons/-/simple-icons-3.13.0.tgz",
+      "integrity": "sha512-sPkiBLbwsXhlP6cQsdVMxt2es+XW+pxLYsNMeNnN0T5mgXEykyvOr4e7FgztPdrdoQBp/KeI1lp863LtqCuiqw==",
       "dev": true
     },
     "source-map": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "pug": "3.0.0",
     "punycode": "2.1.1",
     "puppeteer": "5.5.0",
-    "simple-icons": "2.19.0",
+    "simple-icons": "3.13.0",
     "svg2ttf": "5.0.0",
     "svgpath": "2.3.0",
     "ttf2woff": "2.0.2",


### PR DESCRIPTION
Following the planning discussed in #50 this is in preparation of the next release, v3.13.0, which will match [simple-icons@3.13.0](https://www.npmjs.com/package/simple-icons/v/3.13.0).

* * *

_Since simple-icons removed a number of icons in the release from v2.19.0 to v3.0.0 this is a breaking change, as those icons are also removed from the font._