### PR TITLE
Update simple-icons dependency to v4.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1607,9 +1607,9 @@
       "dev": true
     },
     "simple-icons": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/simple-icons/-/simple-icons-3.13.0.tgz",
-      "integrity": "sha512-sPkiBLbwsXhlP6cQsdVMxt2es+XW+pxLYsNMeNnN0T5mgXEykyvOr4e7FgztPdrdoQBp/KeI1lp863LtqCuiqw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/simple-icons/-/simple-icons-4.0.0.tgz",
+      "integrity": "sha512-uPmPKKSotEfxgg1+QVFPWA4rS9QIvEO46oXvbUpC9mOetA0OCi6CVw8geoufAFK4y5/JTAMp4rd2ZMZyKCrb4Q==",
       "dev": true
     },
     "source-map": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "pug": "3.0.0",
     "punycode": "2.1.1",
     "puppeteer": "5.5.0",
-    "simple-icons": "3.13.0",
+    "simple-icons": "4.0.0",
     "svg2ttf": "5.0.0",
     "svgpath": "2.3.0",
     "ttf2woff": "2.0.2",


### PR DESCRIPTION
Following the planning discussed in #50 this is in preparation of the next release, v4.0.0, which will match [simple-icons@4.0.0](https://www.npmjs.com/package/simple-icons/v/4.0.0).

* * *

_Since simple-icons [removed a number of icons](https://github.com/simple-icons/simple-icons/milestone/3?closed=1) in the release from v3.13.0 to v4.0.0 this is a breaking change, as those icons are also removed from the font._