### PR TITLE
Add issue templates (+ minor change to CONTRIBUTING.md)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -5,6 +5,3 @@ contact_links:
 - name: Icon update
   about: Help us improve by reporting outdated icons
   url: https://github.com/simple-icons/simple-icons/issues/new?labels=icon+outdated&template=icon_update.md
-- name: Packages
-  about: Issues and improvements for the packages
-  url: https://github.com/simple-icons/simple-icons/issues/new?labels=package&template=package.md

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,10 @@
+contact_links:
+- name: Icon request
+  about: Request a new icon for SimpleIcons
+  url: https://github.com/simple-icons/simple-icons/issues/new?labels=new+icon&template=icon_request.md
+- name: Icon update
+  about: Help us improve by reporting outdated icons
+  url: https://github.com/simple-icons/simple-icons/issues/new?labels=icon+outdated&template=icon_update.md
+- name: Packages
+  about: Issues and improvements for the packages
+  url: https://github.com/simple-icons/simple-icons/issues/new?labels=package&template=package.md

--- a/.github/ISSUE_TEMPLATE/font.md
+++ b/.github/ISSUE_TEMPLATE/font.md
@@ -1,0 +1,23 @@
+---
+name: Font
+about: Issues and improvements for the font
+---
+
+<!-- Before opening a new issue search for duplicate or closed issues -->
+
+
+### Kind of issue <!-- Change the one that applies to `[x]`  -->
+
+- [ ] Improvement
+- [ ] Bug
+- [ ] Other, namely:
+
+### Description
+
+
+<!--
+Anything relevant, for example:
+  - For bugs: "Steps to reproduce" and "Expected behavior"
+  - For improvements: An example of a use case
+  - etc.
+-->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,8 @@ Simple Icons welcomes contributions and corrections. Before contributing, please
 1. Commit and push to the new branch
 1. Make a pull request
 
+If you want to request an icon, please [open an issue here][new icon request].
+
 ## Local Development
 
 ### Building Font Locally
@@ -33,5 +35,6 @@ This package is being versioned analog to the `simple-icons` package, the detail
 Additionally, patches may be used for non-breaking improvements to the font and major releases may be used to introduce breakings changes beyond removed icons.
 
 [github flow]: https://guides.github.com/introduction/flow/
+[new icon request]: https://github.com/simple-icons/simple-icons/issues/new?labels=new+icon&template=icon_request.md
 [NodeJS]: https://nodejs.org/en/download/
 [simple-icons versioning]: https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md#versioning


### PR DESCRIPTION
This adds definitions for issue templates (mostly just references to the issue templates of the main project), similar to what can be seen at https://github.com/ericcornelissen/simple-icons-website/issues/new/choose. I'm not 100% sure about the link to the packages issue in `config.yml`... :thinking: 

Also, it adds a link to the Contributing Guidelines for people to request new icons, thought that may be useful but I would be happy to remove it.