### PR TITLE
Update simple-icons dependency to v4.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1607,9 +1607,9 @@
       "dev": true
     },
     "simple-icons": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/simple-icons/-/simple-icons-4.0.0.tgz",
-      "integrity": "sha512-uPmPKKSotEfxgg1+QVFPWA4rS9QIvEO46oXvbUpC9mOetA0OCi6CVw8geoufAFK4y5/JTAMp4rd2ZMZyKCrb4Q==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/simple-icons/-/simple-icons-4.1.0.tgz",
+      "integrity": "sha512-qVYH7huMNS6NhZkhWZj/C8SSlPD4zyHVYbKi0qhuP/3/m++AQ8NU+MXzcEwISg6TnDRCjZrCrzWi/kIAXCjv4g==",
       "dev": true
     },
     "source-map": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "pug": "3.0.0",
     "punycode": "2.1.1",
     "puppeteer": "5.5.0",
-    "simple-icons": "4.0.0",
+    "simple-icons": "4.1.0",
     "svg2ttf": "5.0.0",
     "svgpath": "2.3.0",
     "ttf2woff": "2.0.2",


### PR DESCRIPTION
Following the planning discussed in #50 this is in preparation of the next release, v4.1.0, which will match [simple-icons@4.1.0](https://www.npmjs.com/package/simple-icons/v/4.1.0).

* * *

<sup>I intentionally skipped release [simple-icons@v4.0.1](https://github.com/simple-icons/simple-icons/releases/tag/4.0.1) because it doesn't add or update any icon</sup>