### PR TITLE
 Update simple-icons dependency to v4.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1607,9 +1607,9 @@
       "dev": true
     },
     "simple-icons": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/simple-icons/-/simple-icons-4.1.0.tgz",
-      "integrity": "sha512-qVYH7huMNS6NhZkhWZj/C8SSlPD4zyHVYbKi0qhuP/3/m++AQ8NU+MXzcEwISg6TnDRCjZrCrzWi/kIAXCjv4g==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/simple-icons/-/simple-icons-4.2.0.tgz",
+      "integrity": "sha512-J0gfXJWL4D87qJdOkgLs+ldeFNjzdRHXznyMozpsvgqDVkiEEZW/HNJgoYQ43HvtYngYW/9Av53h/wrg+zeF3g==",
       "dev": true
     },
     "source-map": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "pug": "3.0.0",
     "punycode": "2.1.1",
     "puppeteer": "5.5.0",
-    "simple-icons": "4.1.0",
+    "simple-icons": "4.2.0",
     "svg2ttf": "5.0.0",
     "svgpath": "2.3.0",
     "ttf2woff": "2.0.2",


### PR DESCRIPTION
Following the planning discussed in #50 this is in preparation of the next release, v4.2.0, which will match [simple-icons@4.2.0](https://www.npmjs.com/package/simple-icons/v/4.2.0).