### PR TITLE
Update simple-icons dependency to v4.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1622,9 +1622,9 @@
       "dev": true
     },
     "simple-icons": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/simple-icons/-/simple-icons-4.3.0.tgz",
-      "integrity": "sha512-Khz9p83mq139BsbRuxbk3VYoBPW0mGlmiN6G/BO8HoxPP3Te0LVfFXBVLPxDFGRwPD0MkoNCczMbYfMCI2dQ8g==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/simple-icons/-/simple-icons-4.4.0.tgz",
+      "integrity": "sha512-Hy6dNQpTgiRLAyLlECtnllNJy76TXMEzUSdS2m0xQl+2Cu+W/Pw23uwrIGkb6XgjGN49mDufeiNEfi0w+kwheQ==",
       "dev": true
     },
     "source-map": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "pug": "3.0.0",
     "punycode": "2.1.1",
     "puppeteer": "5.5.0",
-    "simple-icons": "4.3.0",
+    "simple-icons": "4.4.0",
     "svg2ttf": "5.0.0",
     "svgpath": "2.3.0",
     "ttf2woff": "2.0.2",


### PR DESCRIPTION
Following the planning discussed in #50 this is in preparation of the next release, v4.4.0, which will match [simple-icons@4.4.0](https://www.npmjs.com/package/simple-icons/v/4.4.0).