### PR TITLE
Update simple-icons dependency to v4.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1622,9 +1622,9 @@
       "dev": true
     },
     "simple-icons": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/simple-icons/-/simple-icons-4.4.0.tgz",
-      "integrity": "sha512-Hy6dNQpTgiRLAyLlECtnllNJy76TXMEzUSdS2m0xQl+2Cu+W/Pw23uwrIGkb6XgjGN49mDufeiNEfi0w+kwheQ==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/simple-icons/-/simple-icons-4.5.0.tgz",
+      "integrity": "sha512-Z/YvOWQPYTuWWL3Wjf5FvZ7YT2D6cW+16clWVTbEYiAFGCjNouUATgHy+nOb5ywDVE14gU1VRdvCa7/BrnUW6w==",
       "dev": true
     },
     "source-map": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "pug": "3.0.0",
     "punycode": "2.1.1",
     "puppeteer": "5.5.0",
-    "simple-icons": "4.4.0",
+    "simple-icons": "^4.5.0",
     "svg2ttf": "5.0.0",
     "svgpath": "2.3.0",
     "ttf2woff": "2.0.2",


### PR DESCRIPTION
Following the planning discussed in #50 this is in preparation of the next release, v4.5.0, which will match [simple-icons@4.5.0](https://www.npmjs.com/package/simple-icons/v/4.5.0).

<sup>And then we are finally caught up with [the main repo](https://github.com/simple-icons/simple-icons) :tada:</sup>