### PR TITLE
Add at-fileoverviews for scripts

### DIFF
--- a/scripts/build-testpage.js
+++ b/scripts/build-testpage.js
@@ -1,3 +1,9 @@
+#!/usr/bin/env node
+/**
+ * @fileoverview
+ * Builds a test page to display the simple-icons-font.
+ */
+
 // core packages
 const fs = require('fs');
 const path = require('path');

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 /**
  * @fileoverview
- * Builds the simple-icons-font based on the installed simple-icons dependency.
+ * Builds the simple-icons-font package based on the installed simple-icons
+ * dependency.
  */
 
 const fs = require('fs');

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,3 +1,9 @@
+#!/usr/bin/env node
+/**
+ * @fileoverview
+ * Builds the simple-icons-font based on the installed simple-icons dependency.
+ */
+
 const fs = require('fs');
 const path = require('path');
 const util = require('util');

--- a/scripts/bump-version.js
+++ b/scripts/bump-version.js
@@ -1,3 +1,11 @@
+#!/usr/bin/env node
+/**
+ * @fileoverview
+ * Update the simple-icons dependency to the latest version and update the
+ * version of this package accordingly. Upon success, the new version is
+ * outputted.
+ */
+
 const { execSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');

--- a/scripts/bump-version.js
+++ b/scripts/bump-version.js
@@ -1,9 +1,8 @@
 #!/usr/bin/env node
 /**
  * @fileoverview
- * Update the simple-icons dependency to the latest version and update the
- * version of this package accordingly. Upon success, the new version is
- * outputted.
+ * Update the simple-icons dependency to the latest version and the version of
+ * this package accordingly. Upon success, the new version is outputted.
  */
 
 const { execSync } = require('child_process');

--- a/scripts/preview.js
+++ b/scripts/preview.js
@@ -1,3 +1,10 @@
+#!/usr/bin/env node
+/**
+ * @fileoverview
+ * Produce a screenshot of the testpage. The screenshot will be saved in the
+ * root of this repository.
+ */
+
 // npm packages
 const puppeteer = require('puppeteer');
 


### PR DESCRIPTION
Based on [this comment](https://github.com/simple-icons/simple-icons-font/pull/77#pullrequestreview-564431254) and the practice of adding `@fileoverview`s at the top of scripts in the main repo (e.g. [in `build-package.js`](https://github.com/simple-icons/simple-icons/blob/9e09db732429c9d2526d7fb297f1183013875b9c/scripts/build-package.js#L1-L8), this adds an `@fileoverview` to every script in this project as well.