### PR TITLE
Use 'punycode/' require to import the userland module

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -3,7 +3,7 @@ const path = require('path');
 const util = require('util');
 
 const CleanCSS = require('clean-css');
-const { ucs2 } = require('punycode');
+const { ucs2 } = require('punycode/');
 const SimpleIcons = require('simple-icons');
 const svg2ttf = require('svg2ttf');
 const SVGPath = require('svgpath');


### PR DESCRIPTION
The change is minimal. For some reason I added the library in #45 but used the NodeJS builtin version of the library. The instructions for updating are [here](https://github.com/bestiejs/punycode.js#installation).

Closes #88