### PR TITLE
Update Renovate configuration

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,9 +1,33 @@
 {
-  extends: ['config:base'],
+  extends: [
+    'config:base',
+
+    // Make sure we get a single PR combining all updates
+    'group:all',
+  ],
 
   // We will keep simple-icons up-to-date separately from renovate
   ignoreDeps: ['simple-icons'],
 
+  lockFileMaintenance: {
+    extends: [
+      // Make sure we get a single PR combining all updates
+      'group:all',
+    ],
+
+    // Explicitly enable lockfile maintenance
+    enabled: true,
+
+    // This schedule should be the same as the general schedule!
+    schedule: 'on the 2nd and 4th day instance on sunday after 11pm',
+  },
+
   // Use our labelling system
   labels: ['dependencies'],
+
+  // Schedule the PRs to interleave with our release schedule
+  schedule: 'on the 2nd and 4th day instance on sunday after 11pm',
+
+  // We generally always want the major version
+  separateMajorMinor: false,
 }


### PR DESCRIPTION
Following the general idea of [the configuration of Renovate in the main repo](https://github.com/simple-icons/simple-icons/blob/develop/.github/renovate.json5), this updates the Renovate configuration to run on a schedule and to group changes into a single PR.

With #1 closed and development mostly done, I figured we don't need updates as soon as they're available anymore. Arguably we can change the schedule to run even less.