### PR TITLE
General refactoring for consistency

### DIFF
--- a/scripts/build-testpage.js
+++ b/scripts/build-testpage.js
@@ -20,11 +20,16 @@ const attributedIcons = Object.values(simpleIcons).map((icon) => {
   };
 });
 
-pug.renderFile(INPUT_FILE, { icons: attributedIcons }, (err, html) => {
-  if (err) throw err;
+pug.renderFile(INPUT_FILE, { icons: attributedIcons }, (renderError, html) => {
+  if (renderError) {
+    throw renderError;
+  }
 
-  fs.writeFile(OUTPUT_FILE, html, (err) => {
-    if (err) throw err;
+  fs.writeFile(OUTPUT_FILE, html, (writeError) => {
+    if (writeError) {
+      throw writeError;
+    }
+
     console.info('Test page built.');
   });
 });

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -32,12 +32,12 @@ const WOFF2_OUTPUT_FILEPATH = path.join(DIST_DIR, 'SimpleIcons.woff2');
 const CSS_BASE_FILE = path.resolve(__dirname, 'templates', 'base.css');
 const SVG_TEMPLATE_FILEPATH = path.join(__dirname, 'templates', 'font.svg');
 
-const cssDecodeUnicode = (value) => {
+function cssDecodeUnicode(value) {
   // &#xF26E; -> \f26e
   return value.replace('&#x', '\\').replace(';', '').toLowerCase();
-};
+}
 
-const buildSimpleIconsSvgFontFile = () => {
+function buildSimpleIconsSvgFontFile() {
   const usedUnicodes = [];
   const unicodeHexBySlug = [];
   let startUnicode = 0xea01;
@@ -73,9 +73,9 @@ const buildSimpleIconsSvgFontFile = () => {
   console.log(`'${SVG_OUTPUT_FILEPATH}' file built`);
 
   return { unicodeHexBySlug, svgFileContent };
-};
+}
 
-const buildSimpleIconsCssFile = (unicodeHexBySlug) => {
+function buildSimpleIconsCssFile(unicodeHexBySlug) {
   let cssFileContent = fs.readFileSync(CSS_BASE_FILE);
 
   for (let slug in unicodeHexBySlug) {
@@ -90,18 +90,18 @@ const buildSimpleIconsCssFile = (unicodeHexBySlug) => {
   console.log(`'${CSS_OUTPUT_FILEPATH}' file built`);
 
   return cssFileContent;
-};
+}
 
-const buildSimpleIconsMinCssFile = (cssFileContent) => {
+function buildSimpleIconsMinCssFile(cssFileContent) {
   const cssMinifiedFile = new CleanCSS({
     compatibility: 'ie7',
   }).minify(cssFileContent);
 
   fs.writeFileSync(CSS_MIN_OUTPUT_FILEPATH, cssMinifiedFile.styles);
   console.log(`'${CSS_MIN_OUTPUT_FILEPATH}' file built`);
-};
+}
 
-const buildSimpleIconsTtfFontFile = (svgFileContent) => {
+function buildSimpleIconsTtfFontFile(svgFileContent) {
   const ttf = svg2ttf(svgFileContent, {
     version: `Version ${packageJson.version.split('.').slice(0, 2).join('.')}`,
     description: packageJson.description,
@@ -111,21 +111,21 @@ const buildSimpleIconsTtfFontFile = (svgFileContent) => {
   fs.writeFileSync(TTF_OUTPUT_FILEPATH, ttfFileContent);
   console.log(`'${TTF_OUTPUT_FILEPATH}' file built`);
   return ttfFileContent;
-};
+}
 
-const buildSimpleIconsWoffFontFile = (ttfFileContent) => {
+function buildSimpleIconsWoffFontFile(ttfFileContent) {
   const woff = new Buffer.from(ttf2woff(new Uint8Array(ttfFileContent)).buffer);
   fs.writeFileSync(WOFF_OUTPUT_FILEPATH, woff);
   console.log(`'${WOFF_OUTPUT_FILEPATH}' file built`);
-};
+}
 
-const buildSimpleIconsWoff2FontFile = (ttfFileContent) => {
+function buildSimpleIconsWoff2FontFile(ttfFileContent) {
   const woff2 = ttf2woff2(ttfFileContent);
   fs.writeFileSync(WOFF2_OUTPUT_FILEPATH, woff2);
   console.log(`'${WOFF2_OUTPUT_FILEPATH}' file built`);
-};
+}
 
-const main = () => {
+function main() {
   if (!fs.existsSync(DIST_DIR)) {
     fs.mkdirSync(DIST_DIR);
   }
@@ -136,6 +136,6 @@ const main = () => {
   buildSimpleIconsMinCssFile(cssFileContent);
   buildSimpleIconsWoffFontFile(ttfFileContent);
   buildSimpleIconsWoff2FontFile(ttfFileContent);
-};
+}
 
 main();

--- a/scripts/bump-version.js
+++ b/scripts/bump-version.js
@@ -21,8 +21,8 @@ function updateSimpleIconsDependency() {
   try {
     execSync('npm uninstall simple-icons');
     execSync('npm install --save-dev --save-exact simple-icons');
-  } catch (err) {
-    return err;
+  } catch (error) {
+    return error;
   }
 }
 
@@ -40,15 +40,15 @@ function updateVersionNumber() {
       packageFile.version = simpleIconsVersion;
       packageLock.version = simpleIconsVersion;
     } else {
-      const err = new Error(`Version already exists (${currentVersion})`);
-      return [null, err];
+      const error = new Error(`Version already exists (${currentVersion})`);
+      return [null, error];
     }
 
     fs.writeFileSync(PACKAGE_JSON_FILE, stringifyJson(packageFile) + '\n');
     fs.writeFileSync(PACKAGE_LOCK_FILE, stringifyJson(packageLock) + '\n');
     return [simpleIconsVersion, null];
-  } catch (err) {
-    return [null, err];
+  } catch (error) {
+    return [null, error];
   }
 }
 

--- a/scripts/preview.js
+++ b/scripts/preview.js
@@ -16,17 +16,21 @@ const VIEWPORT_720P = {
   deviceScaleFactor: 2,
 };
 
-const capture = async () => {
-  const browser = await puppeteer.launch({ defaultViewport: VIEWPORT_720P });
-  const page = await browser.newPage();
-  await page.goto(TEST_PAGE_URL);
-  await page.screenshot({
-    path: SCREENSHOT_PATH,
-    fullPage: true,
-  });
-  await browser.close();
-};
+async function capture() {
+  try {
+    const browser = await puppeteer.launch({ defaultViewport: VIEWPORT_720P });
+    const page = await browser.newPage();
+    await page.goto(TEST_PAGE_URL);
+    await page.screenshot({
+      path: SCREENSHOT_PATH,
+      fullPage: true,
+    });
+    await browser.close();
+    console.log('Screenshot token');
+  } catch (err) {
+    console.error('Screenshot failed:', err);
+    process.exit(1);
+  }
+}
 
-capture()
-  .then(() => console.log('Screenshot token'))
-  .catch((err) => console.error('Screenshot failed:', err));
+capture();

--- a/scripts/preview.js
+++ b/scripts/preview.js
@@ -27,8 +27,8 @@ async function capture() {
     });
     await browser.close();
     console.log('Screenshot token');
-  } catch (err) {
-    console.error('Screenshot failed:', err);
+  } catch (error) {
+    console.error('Screenshot failed:', error);
     process.exit(1);
   }
 }


### PR DESCRIPTION
Following up on #86, this does some more general refactoring for consistency (open for discussion as always):

- Prevent variable shadowing in `scripts/build-testpage.js`, just because it is good practice.
- Use `function` rather than `const x = () => { }` for top-level functions.
- Normalize the names of variables representing errors (to `error` or `errorXyz`.
- Use only `async`/`await` and no `.then`/`.catch`.
