### PR TITLE
Don't install husky in 'postinstall' if '.git' directory doesn't exists

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "format": "prettier --write --single-quote .",
     "lint": "prettier --check --single-quote .",
     "prepublishOnly": "pinst --disable && npm run build",
-    "postinstall": "is-ci || husky install",
+    "postinstall": "is-ci || node -e \"if (require('fs').existsSync('.git')){process.exit(1)}\" || husky install",
     "postpublish": "pinst --enable && npm run clean",
     "test": "npm run build:testpage && anywhere -h localhost -d . -f /preview/testpage.html"
   },


### PR DESCRIPTION
I know that this is an edge case, but I found it interesting. If you download the repository using Github UI (`Code` -> `Download ZIP`), extract the repository and executes `npm install`, next error is raised during the installation:

<details>
  <summary>postinstall error</summary>

```
> simple-icons-font@4.9.0 postinstall /.../simple-icons-font-develop
> is-ci || husky install

/.../simple-icons-font-develop/node_modules/husky/lib/commands/install.js:20
        throw new Error(".git can't be found");
        ^

Error: .git can't be found
    at Object.install (/.../simple-icons-font-develop/node_modules/husky/lib/commands/install.js:20:15)
    at Object.<anonymous> (/.../simple-icons-font-develop/node_modules/husky/lib/bin.js:43:19)
```

</details>

Which means that `husky` needs the `.git` directory to exist or will fail. I'm sure that no one would do this, only me on Windows :sweat_smile:, but anyways seems to me that this should be possible because someone could install this only for test it quickly, even if are not planning doing commits.

The proposed change seems counterintuitive but is the most straightforward way of do this: if `.git` directory does not exists, exits with 0 code and don't executes `husky install`, otherwise the `node -e` command fails and `husky install` is executed.