### PR TITLE
Perform sanity check before automated releases

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -29,6 +29,8 @@ jobs:
         run: |
           newVersion="$(node scripts/bump-version.js)"
           echo ::set-output name=NEW_VERSION::$newVersion
+      - name: Sanity check
+        run: npm run build
       - name: Commit updates
         run: |
           # Set up git credential


### PR DESCRIPTION
The idea is pretty simple, currently the [automated releases job](https://github.com/simple-icons/simple-icons-font/blob/18a5d4634c7405838f2c7fab610d9a0bc86a46d7/.github/workflows/auto-release.yml) will just update the simple-icons dependency and push that back to the repository. At that point the other workflows will verify that everything still works. That is fine, as we won't release anything if [the build script](https://github.com/simple-icons/simple-icons-font/blob/develop/scripts/build.js) no longer works, but it can make for an ugly commit history.

Hence, this adds one step to the automated releases job to check if the build script still works after updating simple-icons and before pushing changes.