### PR TITLE
Add composer.json to publish to Packagist

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Free SVG icon font for popular brands. See them all on one page at <a href="http
 <p align="center">
 <a href="https://github.com/simple-icons/simple-icons-font/actions?query=workflow%3AVerify+branch%3Adevelop"><img src="https://img.shields.io/github/workflow/status/simple-icons/simple-icons-font/Verify/develop?logo=github" alt="Build status" /></a>
 <a href="https://www.npmjs.com/package/simple-icons-font"><img src="https://img.shields.io/npm/v/simple-icons-font?logo=npm" alt="NPM version" /></a>
+<a href="https://packagist.org/packages/simple-icons/simple-icons-font"><img src="https://img.shields.io/packagist/v/simple-icons/simple-icons-font?logo=packagist&logoColor=white" alt="Build status" /></a>
 </p>
 
 ## Setup

--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ $ npm install simple-icons-font
 
 After installation, the icons font and stylesheet font can be found in `node_modules/simple-icons-font/font`. You can use your favorite bundling tool to include them into your project.
 
+### PHP Setup
+
+The font is also available through our Packagist package. To install, simply run:
+
+```
+$ composer require simple-icons-font
+```
+
+The font can then be used by linking to the stylesheet in your HTML or PHP file (see example in [Manual Setup](#manual-setup)).
+
 ### Manual Setup
 
 You can also [download the latest version of the package][latest-release] and copy the content of the `font` folder into your project. Then, reference the CSS file using a `link` tag in your HTML:

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,15 @@
+{
+  "name": "simple-icons/simple-icons-font",
+  "description": "Icon font generated from https://simpleicons.org",
+  "homepage": "https://simpleicons.org/",
+  "keywords": [
+    "svg",
+    "icons",
+    "font",
+    "typeface"
+  ],
+  "support": {
+    "issues": "https://github.com/simple-icons/simple-icons/issues"
+  },
+  "license": "CC0-1.0"
+}


### PR DESCRIPTION
This Pull Request is based on https://github.com/simple-icons/simple-icons/pull/1611.

This adds a `composer.json` file which, combined with [our GitHub releases](https://github.com/simple-icons/simple-icons-font/releases), will allow us to publish the font to [Packagist](https://packagist.org/) in addition to NPM similar to [the simple-icons package on Packagist](https://packagist.org/packages/simple-icons/simple-icons). The documentation in the README has also been updated to include a section on PHP usage.