### PR TITLE
Remove 'pinst' dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -651,12 +651,6 @@
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
       "dev": true
     },
-    "fromentries": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.3.2.tgz",
-      "integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==",
-      "dev": true
-    },
     "fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
@@ -1260,15 +1254,6 @@
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
-    },
-    "pinst": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/pinst/-/pinst-2.1.6.tgz",
-      "integrity": "sha512-B4dYmf6nEXg1NpDSB+orYWvKa5Kfmz5KzWC29U59dpVM4S/+xp0ak/JMEsw04UQTNNKps7klu0BUalr343Gt9g==",
-      "dev": true,
-      "requires": {
-        "fromentries": "^1.3.2"
-      }
     },
     "pkg-dir": {
       "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "clean-css": "5.1.0",
     "husky": "5.1.3",
     "is-ci": "3.0.0",
-    "pinst": "2.1.6",
     "prettier": "2.2.1",
     "pug": "3.0.2",
     "punycode": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
     "clean": "rm -rf font/ preview/testpage.html screenshot.png",
     "format": "prettier --write --single-quote .",
     "lint": "prettier --check --single-quote .",
+    "prepublishOnly": "npm run build",
     "prepare": "is-ci || husky install",
+    "postpublish": "npm run clean",
     "test": "npm run build:testpage && anywhere -h localhost -d . -f /preview/testpage.html"
   },
   "devDependencies": {
@@ -34,6 +36,7 @@
     "clean-css": "5.1.0",
     "husky": "5.1.3",
     "is-ci": "3.0.0",
+    "pinst": "2.1.6",
     "prettier": "2.2.1",
     "pug": "3.0.2",
     "punycode": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -25,9 +25,7 @@
     "clean": "rm -rf font/ preview/testpage.html screenshot.png",
     "format": "prettier --write --single-quote .",
     "lint": "prettier --check --single-quote .",
-    "prepublishOnly": "pinst --disable && npm run build",
     "prepare": "is-ci || husky install",
-    "postpublish": "pinst --enable && npm run clean",
     "test": "npm run build:testpage && anywhere -h localhost -d . -f /preview/testpage.html"
   },
   "devDependencies": {
@@ -36,7 +34,6 @@
     "clean-css": "5.1.0",
     "husky": "5.1.3",
     "is-ci": "3.0.0",
-    "pinst": "2.1.6",
     "prettier": "2.2.1",
     "pug": "3.0.2",
     "punycode": "2.1.1",


### PR DESCRIPTION
Following from #105. Removes **pinst** dependency ~~and `prepublishOnly` and `postpublish` scripts from `package.json`~~.