### PR TITLE
Update CDN urls in the README setup documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Free SVG icon font for popular brands. See them all on one page at <a href="http
 The font can be served from a CDN such as [JSDelivr][jsdelivr-link] or [Unpkg][unpkg-link]. Simply use the `simple-icons-font` NPM package and specify a version in the URL like the following:
 
 ```html
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/simple-icons-font@v4/font/simple-icons.min.css" type="text/css">
-<link rel="stylesheet" href="https://unpkg.com/simple-icons-font@4/font/simple-icons.min.css" type="text/css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/simple-icons-font@v5/font/simple-icons.min.css" type="text/css">
+<link rel="stylesheet" href="https://unpkg.com/simple-icons-font@v5/font/simple-icons.min.css" type="text/css">
 ```
 
 These examples use the latest major version. This means you won't receive any updates following the next major release. You can use `@latest` instead to receive updates indefinitely. However this may cause an icon to disappear if it has been removed in the latest version.


### PR DESCRIPTION
Side note: I added a "v" to the Unpkg URL for consistency with the JSDelivr URL and [these URLs in the main repository](https://github.com/simple-icons/simple-icons#cdn-usage). This is functionally equivalent to the same URL without the "v".