### PR TITLE
Make code snippets easier to copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,15 @@ Free SVG icon font for popular brands. See them all on one page at <a href="http
 
 The font can be served from a CDN such as [JSDelivr][jsdelivr-link] or [Unpkg][unpkg-link]. Simply use the `simple-icons-font` NPM package and specify a version in the URL like the following:
 
+#### JSDeliver
+
 ```html
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/simple-icons-font@v4/font/simple-icons.min.css" type="text/css">
+```
+
+#### Unpkg
+
+```html
 <link rel="stylesheet" href="https://unpkg.com/simple-icons-font@4/font/simple-icons.min.css" type="text/css">
 ```
 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ These examples use the latest major version. This means you won't receive any up
 
 The font is also available through our npm package. To install, simply run:
 
-```
-$ npm install simple-icons-font
+```shell
+npm install simple-icons-font
 ```
 
 After installation, the icons font and stylesheet font can be found in `node_modules/simple-icons-font/font`. You can use your favorite bundling tool to include them into your project.
@@ -40,8 +40,8 @@ After installation, the icons font and stylesheet font can be found in `node_mod
 
 The font is also available through our Packagist package. To install, simply run:
 
-```
-$ composer require simple-icons-font
+```shell
+composer require simple-icons-font
 ```
 
 The font can then be used by linking to the stylesheet in your HTML or PHP file (see example in [Manual Setup](#manual-setup)).


### PR DESCRIPTION
_Relates to https://github.com/simple-icons/simple-icons/pull/5736_

---

This updates the snippets in this project's documentation with the goal of making them easier to copy:

- Remove `$` from CLI snippets. It looks nice but it's included when you copy so if you paste it the command doesn't work. 

  I also added the snippet type "shell" to these snippets.

- Split up the CDN example snippets so that you can copy one of them and use it, no need to have both on your website.

---

_Suggestions for other improvements are welcome, e.g. suggestions for the [Usage](https://github.com/simple-icons/simple-icons-font#usage) examples_