### PR TITLE
Include DISCLAIMER.md from simple-icons in releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+DISCLAIMER.md
+
 # Dependency directories
 node_modules/
 

--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,13 @@
-# Keep only the icon font files
+# Ignore all files in root
 /*
+# Except the ones we want to publish
 !/font/
+!package.json
+!DISCLAIMER.md
+!README.md
+!LICENSE.md
+!index.js
+
+# But exclude the .svg font file, as per:
+# https://github.com/simple-icons/simple-icons-font/pull/45#discussion_r539539508
 /font/SimpleIcons.svg

--- a/package.json
+++ b/package.json
@@ -22,10 +22,10 @@
   "scripts": {
     "build": "node scripts/build.js",
     "build:testpage": "npm run build && node scripts/build-testpage.js",
-    "clean": "rm -rf font/ preview/testpage.html screenshot.png",
+    "clean": "rm -rf font/ preview/testpage.html DISCLAIMER.md screenshot.png",
     "format": "prettier --write --single-quote .",
     "lint": "prettier --check --single-quote .",
-    "prepublishOnly": "npm run build",
+    "prepublishOnly": "npm run build && cp node_modules/simple-icons/DISCLAIMER.md ./",
     "prepare": "is-ci || husky install",
     "postpublish": "npm run clean",
     "test": "npm run build:testpage && anywhere -h localhost -d . -f /preview/testpage.html"


### PR DESCRIPTION
Closes #121

---

This ensures [the `DISCLAIMER.md` file of the main project](https://github.com/simple-icons/simple-icons/blob/develop/DISCLAIMER.md) is included in release of this package. This is achieved by copying it into the root of the project in the `prepublishOnly` script. Additionally, it was added to the `.npmignore` file so that it is actually published (and I also updated `.npmignore` to be more explicit & in-line with [the main project's `.npmignore`](https://github.com/simple-icons/simple-icons/blob/24ae192ef7411477231a4bcc03109a741ad691a3/.npmignore)).

I also included `DISCLAIMER.md` in this project's `.gitignore` to avoid it from ever being committed, even though the `npm run clean` command should take care of removing it after publishing.