### PR TITLE
Improve GitHub releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,3 +50,5 @@ jobs:
         with:
           tag_name: ${{ steps.get-version.outputs.version }}
           release_name: Release ${{ steps.get-version.outputs.version }}
+          body: |
+            See https://github.com/simple-icons/simple-icons/releases/tag/${{ steps.get-version.outputs.version }}


### PR DESCRIPTION
Add a link to the [simple-icons/simple-icons](https://github.com/simple-icons/simple-icons) release notes (i.e. GitHub release) to the GitHub releases of this font so it's easier for anyone stumbling on the GitHub releases for this project to find the changes of that version.