### PR TITLE
Add Windows support for `clean` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "build": "node scripts/build.js",
     "build:testpage": "npm run build && node scripts/build-testpage.js",
-    "clean": "rm -rf font/ preview/testpage.html DISCLAIMER.md screenshot.png",
+    "clean": "rimraf font/ preview/testpage.html DISCLAIMER.md screenshot.png",
     "format": "prettier --write .",
     "lint": "prettier --check .",
     "prepublishOnly": "npm run build && cp node_modules/simple-icons/DISCLAIMER.md ./",
@@ -40,6 +40,7 @@
     "pug": "3.0.2",
     "punycode": "2.1.1",
     "puppeteer": "10.4.0",
+    "rimraf": "3.0.2",
     "semver": "7.3.5",
     "simple-icons": "5.21.1",
     "svg2ttf": "6.0.3",


### PR DESCRIPTION
The same change [has been included](https://github.com/simple-icons/simple-icons/pull/6450) in simple-icons and simple-icons-pdf repositories. Note that _rimraf_ is already a dependency of other packages, so this doesn't increments `node_modules` size.