### PR TITLE
Correct vertical positioning error in font glyphs

### DIFF
--- a/scripts/templates/font.svg
+++ b/scripts/templates/font.svg
@@ -4,7 +4,7 @@
   <metadata>CC0 1.0 Universal | simple-icons contributors</metadata>
   <defs>
     <font id="Simple Icons" horiz-adv-x="1200">
-    <font-face font-family="Simple Icons" units-per-em="1200" ascent="-1" descent="1200"/>
+    <font-face font-family="Simple Icons" units-per-em="1200" ascent="-13" descent="1200"/>
     <missing-glyph horiz-adv-x="0"/>
     %s
     </font>


### PR DESCRIPTION
This should fix the issue #113, but the patch needs to be tested by they. I've measured the remaining vertical space at the top and bottom with Inkscape to ensure that `ascent="-13"` is the correct value.