### PR TITLE
Push tag manually in 'Publish Releases' workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,17 +49,21 @@ jobs:
         with:
           files: README.md
           strict: true
-      # Add commit that will only be included in the tag
+      - name: Configure GIT credentials
+        run: |
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+      # Commit that will only be included in the tag
       - name: Commit dark theme images strip
         run: |
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git config --global user.name "github-actions[bot]"
           git add README.md
           git commit -m 'Strip README dark theme image links'
       - name: Create and push git tag
-        uses: actions-ecosystem/action-push-tag@v1
-        with:
-          tag: ${{ steps.get-version.outputs.version }}
+        run: |
+          set -e
+          tag="${{ steps.get-version.outputs.version }}"
+          git tag -a "${tag}"
+          git push origin "${tag}"
       - name: Create GitHub release
         uses: actions/create-release@v1
         env:


### PR DESCRIPTION
The latest version failed tagging the release. See https://github.com/simple-icons/simple-icons/issues/7339

Just drop the action and tag releases manually.