### PR TITLE
Upgrade `strip-gh-theme-links` action to v3

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
       - name: Remove dark theme images from README
-        uses: mondeja/strip-gh-theme-links@v2
+        uses: mondeja/strip-gh-theme-links@v3
         with:
           files: README.md
           strict: true
@@ -45,7 +45,7 @@ jobs:
           export PACKAGE_VERSION=$(cat package.json | grep 'version' | sed 's/[ \",:]//g' | sed 's/version//')
           echo "::set-output name=version::$PACKAGE_VERSION"
       - name: Remove dark theme images from README
-        uses: mondeja/strip-gh-theme-links@v2
+        uses: mondeja/strip-gh-theme-links@v3
         with:
           files: README.md
           strict: true


### PR DESCRIPTION
Following from https://github.com/simple-icons/simple-icons/pull/7389