### PR TITLE
Explicitly set empty tag message publishing releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,7 +62,7 @@ jobs:
         run: |
           set -e
           tag="${{ steps.get-version.outputs.version }}"
-          git tag -a "${tag}"
+          git tag -a "${tag}" -m ""
           git push origin "${tag}"
       - name: Create GitHub release
         uses: actions/create-release@v1


### PR DESCRIPTION
Latest release [has failed](https://github.com/simple-icons/simple-icons-font/runs/6340238939?check_suite_focus=true) because I've not specified tag message creating releases in #159. If you use `set -e && EDITOR="" git tag -a "foo"` GIT exists with non-zero exit code and skips the tag creation.