### PR TITLE
Convert scripts to ESM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules/
 font/
 preview/testpage.html
 screenshot.png
+*.tgz

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,7 +1,5 @@
 #!/bin/sh
 . "$(dirname $0)/_/husky.sh"
 
-git stash -q --keep-index
 npm run format
 git add .
-git stash pop -q

--- a/.npmignore
+++ b/.npmignore
@@ -6,7 +6,6 @@
 !DISCLAIMER.md
 !README.md
 !LICENSE.md
-!index.js
 
 # But exclude the .svg font file, as per:
 # https://github.com/simple-icons/simple-icons-font/pull/45#discussion_r539539508

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,4 +1,0 @@
-module.exports = {
-  trailingComma: 'all',
-  singleQuote: true,
-};

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,4 @@
+{
+  "trailingComma": "all",
+  "singleQuote": true
+}

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,3 @@
-
 # CC0 1.0 Universal
 
 ## Statement of Purpose

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "simple-icons-font",
-      "version": "6.20.0",
+      "version": "6.21.0",
       "license": "CC0-1.0",
       "devDependencies": {
         "@prettier/plugin-pug": "1.20.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "font",
     "typeface"
   ],
-  "main": "index.js",
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/simple-icons/simple-icons-font.git"
@@ -23,6 +22,7 @@
     "type": "opencollective",
     "url": "https://opencollective.com/simple-icons"
   },
+  "type": "module",
   "scripts": {
     "build": "node scripts/build.js",
     "build:testpage": "npm run build && node scripts/build-testpage.js",

--- a/scripts/build-testpage.js
+++ b/scripts/build-testpage.js
@@ -4,14 +4,17 @@
  * Builds a test page to display the simple-icons-font.
  */
 
-const fs = require('fs');
-const pug = require('pug');
-const path = require('path');
-const simpleIcons = require('simple-icons');
+import fs from 'node:fs';
+import path from 'node:path';
+import pug from 'pug';
+import simpleIcons from 'simple-icons';
+import { fileURLToPath } from 'node:url';
 
-const BASE_PATH = path.join(__dirname, '..');
-const INPUT_FILE = path.join(BASE_PATH, 'preview', 'html', 'testpage.pug');
-const OUTPUT_FILE = path.join(BASE_PATH, 'preview', 'testpage.html');
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const ROOT_DIR = path.resolve(__dirname, '..');
+const INPUT_FILE = path.join(ROOT_DIR, 'preview', 'html', 'testpage.pug');
+const OUTPUT_FILE = path.join(ROOT_DIR, 'preview', 'testpage.html');
 
 const attributedIcons = Object.values(simpleIcons).map((icon) => {
   return {
@@ -25,11 +28,6 @@ pug.renderFile(INPUT_FILE, { icons: attributedIcons }, (renderError, html) => {
     throw renderError;
   }
 
-  fs.writeFile(OUTPUT_FILE, html, (writeError) => {
-    if (writeError) {
-      throw writeError;
-    }
-
-    console.info('Test page built.');
-  });
+  fs.writeFileSync(OUTPUT_FILE, html);
+  console.info('Test page built.');
 });

--- a/scripts/preview.js
+++ b/scripts/preview.js
@@ -5,8 +5,11 @@
  * root of this repository.
  */
 
-const path = require('path');
-const puppeteer = require('puppeteer');
+import path from 'node:path';
+import puppeteer from 'puppeteer';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const SCREENSHOT_PATH = path.join(__dirname, '..', 'screenshot.png');
 const TEST_PAGE_URL = 'http://localhost:8080/';
@@ -16,7 +19,7 @@ const VIEWPORT_720P = {
   deviceScaleFactor: 2,
 };
 
-async function capture() {
+(async () => {
   try {
     const browser = await puppeteer.launch({ defaultViewport: VIEWPORT_720P });
     const page = await browser.newPage();
@@ -31,6 +34,4 @@ async function capture() {
     console.error('Screenshot failed:', error);
     process.exit(1);
   }
-}
-
-capture();
+})();


### PR DESCRIPTION
Also includes other improvements like:

- Promisfy build script to improve performance.
- Use `npm view simple-icons --json` sys call in bump version script to improve performance if no upgrade is needed.