### PR TITLE
Update README to use v9.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ The font can be served from a CDN such as [JSDelivr][jsdelivr-link] or [Unpkg][u
 #### JSDelivr
 
 ```html
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/simple-icons-font@v5/font/simple-icons.min.css" type="text/css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/simple-icons-font@v9/font/simple-icons.min.css" type="text/css">
 ```
 
 #### Unpkg
 
 ```html
-<link rel="stylesheet" href="https://unpkg.com/simple-icons-font@v5/font/simple-icons.min.css" type="text/css">
+<link rel="stylesheet" href="https://unpkg.com/simple-icons-font@v9/font/simple-icons.min.css" type="text/css">
 ```
 
 These examples use the latest major version. This means you won't receive any updates following the next major release. You can use `@latest` instead to receive updates indefinitely. However this may cause an icon to disappear if it has been removed in the latest version.


### PR DESCRIPTION
I noticed while browsing this repo we're still using v5 as our example version when people visit the repo.
Updated to v9 so we're keeping pace with the main repo.