### PR TITLE
Only run Verify workflow on push against develop and master branches

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,5 +1,10 @@
 name: Verify
-on: [pull_request, push]
+on:
+  pull_request:
+  push:
+    branches:
+      - develop
+      - master
 
 permissions:
   contents: read


### PR DESCRIPTION
Following from https://github.com/simple-icons/simple-icons/pull/10883