### PR TITLE
Add support for multiple font styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,13 @@ Where `[ICON NAME]` is replaced by the icon name, for example:
 <i class="si si-simpleicons si--color"></i>
 ```
 
+Or use the fit style font, all font will rendered in the same height:
+
+```html
+<i class="si-fit si-simpleicons"></i>
+<i class="si-fit si-simpleicons si--color"></i>
+```
+
 In this example we use the `<i>` tag, but any inline HTML tag should work as you expect.
 
 ## Custom Builds

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "semver": "7.7.1",
         "serve": "14.2.4",
         "simple-icons": "14.15.0",
+        "svg-path-bbox": "2.1.0",
         "svg2ttf": "6.0.3",
         "svgpath": "2.6.0",
         "ttf2eot": "3.1.0",
@@ -1723,9 +1724,9 @@
       "license": "MIT"
     },
     "node_modules/glob": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.0.tgz",
-      "integrity": "sha512-9UiX/Bl6J2yaBbxKoEBRm4Cipxgok8kQYcOPEhScPwebu2I0HoQOuYdIO6S3hLuWoZgpDpwQZMzTFxgpkyT76g==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.1.tgz",
+      "integrity": "sha512-zrQDm8XPnYEKawJScsnM0QzobJxlT/kHOOlRTio8IH/GrmxRE5fjllkzdaHclIuNjUQTJYH2xHNIGfdpJkDJUw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -3747,6 +3748,22 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/svg-path-bbox": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/svg-path-bbox/-/svg-path-bbox-2.1.0.tgz",
+      "integrity": "sha512-PEoSQFbBvL7FOCE4cN8Knej6L7bXdNkjPcUYsfMMpq0HpnqiO0sE2mcXTd7LX160aOyh5HbaeN/SoY8thMk5Kg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "svgpath": "^2.6.0"
+      },
+      "bin": {
+        "svg-path-bbox": "src/cli.js"
+      },
+      "engines": {
+        "node": ">=6.17.1"
       }
     },
     "node_modules/svg2ttf": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "semver": "7.7.1",
     "serve": "14.2.4",
     "simple-icons": "14.15.0",
+    "svg-path-bbox": "2.1.0",
     "svg2ttf": "6.0.3",
     "svgpath": "2.6.0",
     "ttf2eot": "3.1.0",

--- a/preview/assets/script.js
+++ b/preview/assets/script.js
@@ -1,8 +1,9 @@
 document.addEventListener('DOMContentLoaded', () => {
   const $body = document.querySelector('body');
-  const $icons = document.getElementsByClassName('si');
+  const $icons = document.getElementsByTagName('i');
   const $backgroundModeButton = document.querySelector('.background-mode');
   const $iconsColorButton = document.querySelector('.icons-color');
+  const $iconsStyleButton = document.querySelector('.icons-style');
 
   // Background dark/light mode toggler
   $backgroundModeButton.addEventListener('click', () => {
@@ -24,6 +25,29 @@ document.addEventListener('DOMContentLoaded', () => {
 
     for (let i = 0; i < $icons.length; i++) {
       $icons[i].classList.toggle('si--color');
+    }
+  });
+
+  // Icons style toggle
+  $iconsStyleButton.addEventListener('click', () => {
+    const isFit = $icons[0].classList.contains('si-fit');
+    if (isFit) {
+      $iconsStyleButton.innerText = 'Fit';
+    } else {
+      $iconsStyleButton.innerText = 'Regular';
+    }
+
+    for (let i = 0; i < $icons.length; i++) {
+      if ($icons[i].classList.contains('style-immutable')) {
+        continue;
+      }
+      if (isFit) {
+        $icons[i].classList.remove('si-fit');
+        $icons[i].classList.add('si');
+      } else {
+        $icons[i].classList.remove('si');
+        $icons[i].classList.add('si-fit');
+      }
     }
   });
 });

--- a/preview/assets/style.css
+++ b/preview/assets/style.css
@@ -19,7 +19,8 @@ body.dark {
   cursor: pointer;
 }
 
-i.si {
+i.si,
+i.si-fit {
   display: inline-block;
   cursor: help;
 }
@@ -28,7 +29,8 @@ p.grid {
   font-size: 32px;
 }
 
-p.grid i.si {
+p.grid i.si,
+p.grid i.si-fit {
   margin: 0 4px;
   padding: 4px;
   border: 1px dashed gray;

--- a/preview/html/testpage.pug
+++ b/preview/html/testpage.pug
@@ -15,6 +15,7 @@ body
   .buttons-list
     button.background-mode Dark background
     button.icons-color Colorless icons
+    button.icons-style Fit
 
   p.grid
     each icon in icons
@@ -24,3 +25,7 @@ body
     | An icon like #[i.si.si--color.si-github(title='Github')] inside a paragraph.
   p.paragraph
     | An icon like #[em #[i.si.si--color.si-github(title='Github')]] in italics inside a paragraph.
+  p.paragraph
+    | The icon in regular style #[i.si.si--color.si-go.style-immutable(title='Go')] in a paragraph.
+  p.paragraph
+    | The wide icon in fit style #[i.si-fit.si--color.si-go.style-immutable(title='Go')] in a paragraph.

--- a/scripts/templates/base.css
+++ b/scripts/templates/base.css
@@ -8,8 +8,24 @@
     url(SimpleIcons.eot) format('embedded-opentype');
 }
 
+@font-face {
+  font-family: 'Simple Icons Fit';
+  src:
+    url(SimpleIcons-Fit.woff) format('woff'),
+    url(SimpleIcons-Fit.woff2) format('woff2'),
+    url(SimpleIcons-Fit.ttf) format('truetype'),
+    url(SimpleIcons-Fit.otf) format('opentype'),
+    url(SimpleIcons-Fit.eot) format('embedded-opentype');
+}
+
 .si {
   font-style: normal;
   font-family: 'Simple Icons', sans-serif;
+  vertical-align: middle;
+}
+
+.si-fit {
+  font-style: normal;
+  font-family: 'Simple Icons Fit', sans-serif;
   vertical-align: middle;
 }

--- a/scripts/templates/font.svg
+++ b/scripts/templates/font.svg
@@ -4,7 +4,7 @@
   <metadata>CC0 1.0 Universal | simple-icons contributors</metadata>
   <defs>
     <font id="Simple Icons" horiz-adv-x="1200" vert-origin-x="0" vert-origin-y="0">
-    <font-face font-family="Simple Icons" units-per-em="1200" ascent="1200" descent="0"/>
+    <font-face font-family="Simple Icons" font-style="%s" units-per-em="1200" ascent="1200" descent="0"/>
     <missing-glyph horiz-adv-x="0"/>
     %s
     </font>


### PR DESCRIPTION
Related to #222
Resolves #211

### Get a preview build

Download it from: [simple-icons-font-multi-styles.zip](https://github.com/user-attachments/files/18266580/simple-icons-font-multi-styles.zip)

### Changes

- This changed the default font style to the same aspect ratio as the icon. Users still can use the squared version with the `SimpleIcons-Squared.[ext]` font file
- Re-organized the font file locations since we added a new style
- Specify the `font-style` in the font SVG template

### Web browser preview

![](https://github.com/user-attachments/assets/50ab7ced-44c1-4c41-958f-93fe9fdf9738)

### Typeface preview

| Before | After |
|:-:|:-:|
|![](https://github.com/user-attachments/assets/2f326721-f378-4ab8-bf04-21860ed288b2)|![](https://github.com/user-attachments/assets/6077129d-c92a-4f72-a2e2-b1b92aafab65)| 

### File tree

```
font
├── simple-icons.css
├── simple-icons.min.css
├── simple-icons.json
├── simple-icons.min.json
├── SimpleIcons.eot
├── SimpleIcons-Fit.eot
├── SimpleIcons.otf
├── SimpleIcons-Fit.otf
├── SimpleIcons.svg
├── SimpleIcons-Fit.svg
├── SimpleIcons.ttf
├── SimpleIcons-Fit.ttf
├── SimpleIcons.woff
├── SimpleIcons-Fit.woff
├── SimpleIcons.woff2
└── SimpleIcons-Fit.woff2
```


