### PR TITLE
No sandboxed puppeteer launch

### DIFF
--- a/scripts/preview.js
+++ b/scripts/preview.js
@@ -21,7 +21,10 @@ const VIEWPORT_720P = {
 
 (async () => {
   try {
-    const browser = await puppeteer.launch({ defaultViewport: VIEWPORT_720P });
+    const browser = await puppeteer.launch({
+      defaultViewport: VIEWPORT_720P,
+      args: ['--no-sandbox', '--disable-setuid-sandbox']
+    });
     const page = await browser.newPage();
     await page.goto(TEST_PAGE_URL);
     await page.screenshot({

--- a/scripts/preview.js
+++ b/scripts/preview.js
@@ -23,7 +23,7 @@ const VIEWPORT_720P = {
   try {
     const browser = await puppeteer.launch({
       defaultViewport: VIEWPORT_720P,
-      args: ['--no-sandbox', '--disable-setuid-sandbox']
+      args: ['--no-sandbox', '--disable-setuid-sandbox'],
     });
     const page = await browser.newPage();
     await page.goto(TEST_PAGE_URL);

--- a/scripts/templates/base.css
+++ b/scripts/templates/base.css
@@ -1,7 +1,6 @@
 @font-face {
   font-family: 'Simple Icons';
-  src:
-    url(SimpleIcons.woff) format('woff'),
+  src: url(SimpleIcons.woff) format('woff'),
     url(SimpleIcons.woff2) format('woff2'),
     url(SimpleIcons.ttf) format('truetype'),
     url(SimpleIcons.otf) format('opentype'),

--- a/scripts/templates/base.css
+++ b/scripts/templates/base.css
@@ -1,6 +1,7 @@
 @font-face {
   font-family: 'Simple Icons';
-  src: url(SimpleIcons.woff) format('woff'),
+  src:
+    url(SimpleIcons.woff) format('woff'),
     url(SimpleIcons.woff2) format('woff2'),
     url(SimpleIcons.ttf) format('truetype'),
     url(SimpleIcons.otf) format('opentype'),


### PR DESCRIPTION
Fixes #214. See https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md#setting-up-chrome-linux-sandbox

> In order to protect the host environment from untrusted web content, Chrome uses [multiple layers of sandboxing](https://chromium.googlesource.com/chromium/src/+/HEAD/docs/linux/sandboxing.md). For this to work properly, the host should be configured first. If there's no good sandbox for Chrome to use, it will crash with the error `No usable sandbox!`.
>
> If you **absolutely trust** the content you open in Chrome, you can launch Chrome with the `--no-sandbox` argument

We absolutely trust the content that we're opening as is a page created by ourselves.
