### PR TITLE
Add support for custom builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,38 @@ Where `[ICON NAME]` is replaced by the icon name, for example:
 
 In this example we use the `<i>` tag, but any inline HTML tag should work as you expect.
 
+## Custom Builds
+
+You can specify which icons need to be build for a smaller file size.
+
+1. Clone and install dependencies:
+
+```shell
+git clone git@github.com:simple-icons/simple-icons-font.git
+cd simple-icons-font
+npm install
+```
+
+2. Use environment variable `SI_FONT_SLUGS_FILTER` to filter icons to include:
+
+```shell
+SI_FONT_SLUGS_FILTER=github,simpleicons npm run build
+```
+
+Next environment variables are available to customize the build:
+
+- `SI_FONT_SLUGS_FILTER`: Comma separated string of slugs to include in the build. See [all slugs].
+- `SI_FONT_PRESERVE_UNICODES`: By default, the build will retain the same unicode of an icon as the full build. You can set it to `false` to disable this.
+
+For example, if you set `SI_FONT_PRESERVE_UNICODES` to `false`, the unicode will still start at `0xea01` and keep increasing even you skipped some icons:
+
+```shell
+SI_FONT_SLUGS_FILTER=github,simpleicons SI_FONT_PRESERVE_UNICODES=false npm run build
+#=> github      \u{EA01}
+#=> simpleicons \u{EA02}
+```
+
 [latest-release]: https://github.com/simple-icons/simple-icons-font/releases/latest
 [jsdelivr-link]: https://www.jsdelivr.com/package/npm/simple-icons-font/
 [unpkg-link]: https://unpkg.com/browse/simple-icons-font/
+[all slugs]: https://github.com/simple-icons/simple-icons/blob/develop/slugs.md

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ cd simple-icons-font
 npm install
 ```
 
-2. Use environment variable `SI_FONT_SLUGS_FILTER` to filter icons to include:
+2. Use the environment variable `SI_FONT_SLUGS_FILTER` to filter icons to include:
 
 ```shell
 SI_FONT_SLUGS_FILTER=github,simpleicons npm run build

--- a/scripts/build-testpage.js
+++ b/scripts/build-testpage.js
@@ -6,8 +6,9 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
+import process from 'node:process';
 import pug from 'pug';
-import { getIconsData, titleToSlug } from 'simple-icons/sdk';
+import { getIconsData, getIconSlug } from 'simple-icons/sdk';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -16,11 +17,16 @@ const ROOT_DIR = path.resolve(__dirname, '..');
 const INPUT_FILE = path.join(ROOT_DIR, 'preview', 'html', 'testpage.pug');
 const OUTPUT_FILE = path.join(ROOT_DIR, 'preview', 'testpage.html');
 
+const { SI_FONT_SLUGS_FILTER = '' } = process.env;
+const siFontSlugs = new Set(SI_FONT_SLUGS_FILTER.split(','));
+
 const iconsData = await getIconsData();
-const icons = iconsData.map((icon) => ({
-  title: icon.title,
-  slug: icon.slug || titleToSlug(icon.title),
-}));
+const icons = iconsData
+  .map((icon) => ({
+    title: icon.title,
+    slug: getIconSlug(icon),
+  }))
+  .filter((icon) => siFontSlugs.size === 0 || siFontSlugs.has(icon.slug));
 
 pug.renderFile(INPUT_FILE, { icons }, (renderError, html) => {
   if (renderError) {


### PR DESCRIPTION
Resolves #163

### Changes

- Add support for custom builds
- Use `getIconSlug()` from `simple-icons/sdk`

### Example

```shell
SI_FONT_SLUGS_FILTER=github,simpleicons npm run build
#=> github      \u{EE3B}
#=> simpleicons \u{F3FE}
```

The `SI_FONT_PRESERVE_UNICODES` is useful when users want to use only a few icons, and the Unicode doesn't change between version updates.

```shell
SI_FONT_SLUGS_FILTER=github,simpleicons SI_FONT_PRESERVE_UNICODES=false npm run build
#=> github      \u{EA01}
#=> simpleicons \u{EA02}
```