### PR TITLE
Remove unneeded lines in Husky pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,2 @@
-#!/bin/sh
-. "$(dirname $0)/_/husky.sh"
-
 npm run format
-git add .
+git add -u


### PR DESCRIPTION
Husky is complaining about this:

```
husky - DEPRECATED

Please remove the following two lines from .husky/pre-commit:

#!/usr/bin/env sh
. "$(dirname -- "$0")/_/husky.sh"

They WILL FAIL in v10.0.0
```

And use `-u` instead of `.` to only update the files affected by `npm run format`.