### PR TITLE
Fix font builds

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -137,7 +137,12 @@ const buildSimpleIconsSvgFontFile = async (style) => {
   }
 
   const svgFontTemplate = await fs.readFile(SVG_TEMPLATE_FILE, UTF8);
-  const svgFileContent = util.format(svgFontTemplate, style, glyphsContent);
+  const svgFileContent = util.format(
+    svgFontTemplate,
+    style === REGULAR_STYLE_NAME ? '' : ` ${style}`, // font id
+    style, // font style
+    glyphsContent,
+  );
   const svgFilename = `${OUTPUT_FILE_NAME}${getStyleSuffix(style)}${SVG_EXTENSION_NAME}`;
   await fs.writeFile(path.join(DIST_DIR, svgFilename), svgFileContent);
   console.log(`'${svgFilename}' file built`);

--- a/scripts/templates/font.svg
+++ b/scripts/templates/font.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg">
   <metadata>CC0 1.0 Universal | simple-icons contributors</metadata>
   <defs>
-    <font id="Simple Icons" horiz-adv-x="1200" vert-origin-x="0" vert-origin-y="0">
+    <font id="Simple Icons%s" horiz-adv-x="1200" vert-origin-x="0" vert-origin-y="0">
     <font-face font-family="Simple Icons" font-style="%s" units-per-em="1200" ascent="1200" descent="0"/>
     <missing-glyph horiz-adv-x="0"/>
     %s


### PR DESCRIPTION
These two font styles should not use the same font id. I've appended the style name to fix this issue.

### How to reproduce this issue

1. Install the 15.0.0 font
    ```shell
    brew install font-simple-icons
    ```
    Or install the 15.0.0 builds manually on your system.

2. Open iTerm2, go to Profile - Text, change the font to Simple Icons
3. Switch font style to Regular, the Regular option cannot be selected