### PR TITLE
Don't run Auto Release nor Renovate workflows in forks

### DIFF
--- a/.github/actions/check-is-fork/action.yml
+++ b/.github/actions/check-is-fork/action.yml
@@ -1,0 +1,28 @@
+# If some workflows are executed in a fork, we don't want to run them
+# because would fail due to missing permissions and will generate
+# noise for activity watchers.
+
+name: Check if running in a fork
+description: Check if a workflow is running in a forked repository and set an output accordingly.
+
+inputs:
+  in-fork-message:
+    description: Message to display when the workflow is running in a fork.
+    required: true
+outputs:
+  is-fork:
+    description: Indicates if the current repository is a fork.
+    value: ${{ steps.check-is-fork.outputs.is-fork }}
+
+runs:
+  using: composite
+  steps:
+    - id: check-is-fork
+      shell: bash
+      run: |
+        if [ "${{ github.repository_owner }}" != "simple-icons" ]; then
+          echo "is-fork=true" >> $GITHUB_OUTPUT
+          echo "${{ inputs.in-fork-message }}"
+        else
+          echo "is-fork=false" >> $GITHUB_OUTPUT
+        fi

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -14,9 +14,21 @@ on:
     - cron: 0 0 * * 2,4,6
 
 jobs:
+  check-is-fork:
+    name: Check if running in a fork
+    runs-on: ubuntu-latest
+    outputs:
+      is-fork: ${{ steps.check.outputs.is-fork }}
+    steps:
+      - uses: ./.github/actions/check-is-fork
+        id: check
+        with:
+          in-fork-message: 'Auto release only can be executed in the main repository, skipping.'
   get-releases:
     name: Get release versions
     runs-on: ubuntu-latest
+    needs: check-is-fork
+    if: needs.check-is-fork.outputs.is-fork != 'true'
     outputs:
       si: ${{ steps.get-releases.outputs.si }}
       lib: ${{ steps.get-releases.outputs.lib }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -6,8 +6,20 @@ on:
   workflow_dispatch:
 
 jobs:
+  check-is-fork:
+    name: Check if running in a fork
+    runs-on: ubuntu-latest
+    outputs:
+      is-fork: ${{ steps.check.outputs.is-fork }}
+    steps:
+      - uses: ./.github/actions/check-is-fork
+        id: check
+        with:
+          in-fork-message: 'Renovate only can be executed in the main repository, skipping.'
   renovate:
     runs-on: ubuntu-latest
+    needs: check-is-fork
+    if: needs.check-is-fork.outputs.is-fork != 'true'
     timeout-minutes: 15
     steps:
       - uses: actions/create-github-app-token@v2


### PR DESCRIPTION
Because permissions are missing.

Prevents things like https://github.com/mondeja/simple-icons-font/actions/runs/15899950591/job/44840339017