### PR TITLE
Update NPM publishing to OIDC authentication

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
     name: NPM Package
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
+      id-token: write # for OIDC authentication
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -33,10 +33,7 @@ jobs:
         run: node scripts/update-cdn-urls.ts
       - name: Deploy to NPM
         if: github.ref == 'refs/heads/master'
-        uses: JS-DevTools/npm-publish@v3
-        with:
-          token: ${{ secrets.NPM_TOKEN }}
-          provenance: true
+        run: npm publish
   github:
     name: GitHub release
     runs-on: ubuntu-latest


### PR DESCRIPTION
Following from https://github.com/simple-icons/svglint/pull/131

In this case, the action has been removed because it requires a `token` input and it appears to be unmaintained. Note that [npm.js suggests to use `npm publish` directly](https://docs.npmjs.com/trusted-publishers#step-2-configure-your-cicd-workflow).

I'll remove the `NPM_TOKEN` secret after this PR is merged and open another PR like this against the main repo after the next release of the font.