### PR TITLE
Fix `github-linguist` classification of TS files as JS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,7 @@ package-lock.json  -diff
 
 # Don't export/archive these files
 .github            export-ignore
+
+# Make github-linguist detect correctly TypeScript files
+# (workaround for https://github.com/github-linguist/linguist/issues/7348)
+*.ts               linguist-language=TypeScript

--- a/scripts/update-cdn-urls.ts
+++ b/scripts/update-cdn-urls.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 /**
  * @fileoverview
  * Updates the CDN URLs in the README.md to match the major version in the


### PR DESCRIPTION
Resolves #246

You can test this by installing the [`github-linguist`](https://github.com/github-linguist/linguist) CLI tool.

### Before

```
simple-icons-font$ github-linguist --breakdown
81.49%  16551      JavaScript
7.44%   1512       TypeScript
6.34%   1287       CSS
4.73%   960        Pug

JavaScript:
  preview/assets/script.js
  scripts/build-testpage.ts
  scripts/build.ts
  scripts/bump-version.ts
  scripts/preview.ts

CSS:
  preview/assets/style.css
  scripts/templates/base.css

Pug:
  preview/html/testpage.pug

TypeScript:
  scripts/types.ts
  scripts/update-cdn-urls.ts

```

### After

```
simple-icons-font$ github-linguist --breakdown
80.64%  16395      TypeScript
8.30%   1688       JavaScript
6.33%   1287       CSS
4.72%   960        Pug

JavaScript:
  preview/assets/script.js

CSS:
  preview/assets/style.css
  scripts/templates/base.css

Pug:
  preview/html/testpage.pug

TypeScript:
  scripts/build-testpage.ts
  scripts/build.ts
  scripts/bump-version.ts
  scripts/preview.ts
  scripts/types.ts
  scripts/update-cdn-urls.ts

```