### PR TITLE
Add Code monospaced style

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,11 +87,18 @@ Where `[ICON NAME]` is replaced by the icon name, for example:
 <i class="si si-simpleicons si--color"></i>
 ```
 
-Or use the fit style font, all font will rendered in the same height:
+Or use the fit style font. It keeps all icons at the same height while allowing wider icons to use wider glyphs:
 
 ```html
 <i class="si-fit si-simpleicons"></i>
 <i class="si-fit si-simpleicons si--color"></i>
+```
+
+Or use the code style font for code or monospace layouts. It uses the same height-based scaling as the fit style and rounds icon widths to fixed-width steps so icons align more predictably with text columns:
+
+```html
+<i class="si-code si-simpleicons"></i>
+<i class="si-code si-simpleicons si--color"></i>
 ```
 
 In this example we use the `<i>` tag, but any inline HTML tag should work as you expect.

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "type": "module",
   "scripts": {
     "build": "node scripts/build.ts",
-    "build:testpage": "npm run build && node scripts/build-testpage.ts",
+    "build:testpage": "node scripts/build-testpage.ts",
     "serve:testpage": "serve -p 3000 --no-clipboard --config preview/serve.json",
     "clean": "rimraf font/ preview/testpage.html DISCLAIMER.md screenshot.png",
     "format": "prettier --write .",

--- a/preview/assets/script.js
+++ b/preview/assets/script.js
@@ -3,7 +3,16 @@ document.addEventListener('DOMContentLoaded', () => {
   const $icons = document.getElementsByTagName('i');
   const $backgroundModeButton = document.querySelector('.background-mode');
   const $iconsColorButton = document.querySelector('.icons-color');
-  const $iconsStyleButton = document.querySelector('.icons-style');
+  const $iconSearchInput = document.querySelector('.icon-search');
+  const $gridIcons = Array.from(document.querySelectorAll('.grid i'));
+  const $iconsCount = document.querySelector('.icons-count');
+  const $emptySearch = document.querySelector('.empty-search');
+  const $iconsStyleInputs = document.querySelectorAll(
+    'input[name="icons-style"]',
+  );
+  const iconStyleClasses = ['si', 'si-fit', 'si-code'];
+  const formatIconsCount = (count) =>
+    `${count} ${count === 1 ? 'icon' : 'icons'}`;
 
   // Background dark/light mode toggler
   $backgroundModeButton.addEventListener('click', () => {
@@ -28,26 +37,47 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 
-  // Icons style toggle
-  $iconsStyleButton.addEventListener('click', () => {
-    const isFit = $icons[0].classList.contains('si-fit');
-    if (isFit) {
-      $iconsStyleButton.innerText = 'Fit';
-    } else {
-      $iconsStyleButton.innerText = 'Regular';
-    }
-
+  // Icons style switcher
+  const setIconsStyle = (style) => {
     for (let i = 0; i < $icons.length; i++) {
       if ($icons[i].classList.contains('style-immutable')) {
         continue;
       }
-      if (isFit) {
-        $icons[i].classList.remove('si-fit');
-        $icons[i].classList.add('si');
-      } else {
-        $icons[i].classList.remove('si');
-        $icons[i].classList.add('si-fit');
-      }
+
+      $icons[i].classList.remove(...iconStyleClasses);
+      $icons[i].classList.add(style);
     }
+  };
+
+  $iconsStyleInputs.forEach(($input) => {
+    $input.addEventListener('change', (event) => {
+      if (event.target.checked) {
+        setIconsStyle(event.target.value);
+      }
+    });
   });
+
+  // Icons search
+  const filterIcons = () => {
+    const query = $iconSearchInput.value.trim().toLowerCase();
+    let visibleIconsCount = 0;
+
+    $gridIcons.forEach(($icon) => {
+      const title = ($icon.dataset.title || '').toLowerCase();
+      const slug = ($icon.dataset.slug || '').toLowerCase();
+      const isVisible =
+        query.length === 0 || title.includes(query) || slug.includes(query);
+
+      $icon.hidden = !isVisible;
+      if (isVisible) {
+        visibleIconsCount++;
+      }
+    });
+
+    $iconsCount.innerText = formatIconsCount(visibleIconsCount);
+    $emptySearch.hidden = visibleIconsCount > 0;
+  };
+
+  $iconSearchInput.addEventListener('input', filterIcons);
+  filterIcons();
 });

--- a/preview/assets/style.css
+++ b/preview/assets/style.css
@@ -7,10 +7,15 @@ body.dark {
   color: #fff;
 }
 
+[hidden] {
+  display: none !important;
+}
+
 .buttons-list {
   display: flex;
-  justify-content: space-around;
-  width: 250px;
+  flex-wrap: wrap;
+  gap: 15px;
+  align-items: center;
   margin-bottom: 25px;
 }
 
@@ -19,8 +24,36 @@ body.dark {
   cursor: pointer;
 }
 
+.icon-search {
+  box-sizing: border-box;
+  width: min(280px, 100%);
+  padding: 5px 8px;
+}
+
+.icons-count {
+  min-width: 70px;
+  white-space: nowrap;
+}
+
+.icons-style {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.icons-style label {
+  display: flex;
+  gap: 4px;
+  align-items: center;
+  cursor: pointer;
+}
+
 i.si,
-i.si-fit {
+i.si-fit,
+i.si-code {
   display: inline-block;
   cursor: help;
 }
@@ -29,11 +62,8 @@ p.grid {
   font-size: 32px;
 }
 
-p.grid i.si,
-p.grid i.si-fit {
-  margin: 0 4px;
-  padding: 4px;
-  border: 1px dashed gray;
+.empty-search {
+  font-size: 18px;
 }
 
 p.paragraph {

--- a/preview/html/testpage.pug
+++ b/preview/html/testpage.pug
@@ -15,11 +15,33 @@ body
   .buttons-list
     button.background-mode Dark background
     button.icons-color Colorless icons
-    button.icons-style Fit
+    input.icon-search(
+      type='search',
+      placeholder='Search icons',
+      aria-label='Search icons',
+      autocomplete='off'
+    )
+    span.icons-count(aria-live='polite')= icons.length + ' icons'
+    fieldset.icons-style(aria-label='Icon style')
+      label
+        input(type='radio', name='icons-style', value='si', checked)
+        | Regular
+      label
+        input(type='radio', name='icons-style', value='si-fit')
+        | Fit
+      label
+        input(type='radio', name='icons-style', value='si-code')
+        | Code
 
   p.grid
     each icon in icons
-      i.si.si--color(class='si-' + icon.slug, title=icon.title)
+      i.si.si--color(
+        class='si-' + icon.slug,
+        title=icon.title,
+        data-title=icon.title,
+        data-slug=icon.slug
+      )
+  p.empty-search(hidden) No icons found.
 
   p.paragraph
     | An icon like #[i.si.si--color.si-github(title='Github')] inside a paragraph.
@@ -29,3 +51,5 @@ body
     | The icon in regular style #[i.si.si--color.si-go.style-immutable(title='Go')] in a paragraph.
   p.paragraph
     | The wide icon in fit style #[i.si-fit.si--color.si-go.style-immutable(title='Go')] in a paragraph.
+  p.paragraph
+    | The icon in code style #[i.si-code.si--color.si-go.style-immutable(title='Go')] in a paragraph.

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -47,8 +47,13 @@ const WOFF2_EXTENSION_NAME = '.woff2';
 
 const REGULAR_STYLE_NAME = 'Regular';
 const FIT_STYLE_NAME = 'Fit';
+const CODE_STYLE_NAME = 'Code';
 
-const TARGET_STYLES: FontStyle[] = [REGULAR_STYLE_NAME, FIT_STYLE_NAME];
+const TARGET_STYLES: FontStyle[] = [
+  REGULAR_STYLE_NAME,
+  FIT_STYLE_NAME,
+  CODE_STYLE_NAME,
+];
 
 const CSS_BASE_FILE = path.resolve(
   import.meta.dirname,
@@ -66,6 +71,11 @@ const cssDecodeUnicode = (value: string) => {
   return value.replace('&#x', '\\').replace(';', '').toLowerCase();
 };
 
+const roundToDecimals = (value: number, decimals = 4) => {
+  const factor = 10 ** decimals;
+  return Math.round(value * factor) / factor;
+};
+
 const { SI_FONT_SLUGS_FILTER = '', SI_FONT_PRESERVE_UNICODES } = process.env;
 const siFontSlugs = new Set(SI_FONT_SLUGS_FILTER.split(',').filter(Boolean));
 const siFontPreseveUnicodes = SI_FONT_PRESERVE_UNICODES !== 'false';
@@ -75,16 +85,53 @@ const verticalTransform = (pathInstance: typeof SVGPath) =>
 
 const convertToAspectRatioViewbox = (pathInstance: typeof SVGPath) => {
   const [x0, y0, x1, y1] = svgPathBbox(pathInstance);
-  const width = x1 - x0;
-  const height = y1 - y0;
+  const width = roundToDecimals(x1 - x0);
+  const height = roundToDecimals(y1 - y0);
   const scale = 24 / height;
   const pathRescale = width > height ? pathInstance.scale(scale) : pathInstance;
-  const [offsetX, offsetY] = svgPathBbox(pathRescale);
-  const pathReset = pathRescale.translate(-offsetX, -offsetY);
-  const [x0Reset, , x1Reset] = svgPathBbox(pathReset);
+  const [offsetX, offsetY, rescaledX1, rescaledY1] = svgPathBbox(pathRescale);
+  const rescaledPath = pathRescale.toString();
+  const rescaledHeight = rescaledY1 - offsetY;
+  const actualWidth = roundToDecimals((rescaledX1 - offsetX) * 50);
+  const fitHorizAdvX = actualWidth;
+  const fitHorizontalPadding = 0;
+  const codeHorizAdvX = Math.max(Math.round(actualWidth / 600) * 600, 600);
+  const codeScale = Math.min(codeHorizAdvX / actualWidth, 1);
+  const codeHorizontalPadding =
+    (codeHorizAdvX - actualWidth * codeScale) / 2 / 50;
+  const codeVerticalPadding =
+    codeScale < 1 ? (24 - rescaledHeight * codeScale) / 2 : 0;
+
+  console.log({
+    width,
+    height,
+    scale,
+    offsetX,
+    offsetY,
+    actualWidth,
+    fitHorizAdvX,
+    codeHorizAdvX,
+  });
+
   return {
-    path: verticalTransform(pathReset),
-    horizAdvX: ((x1Reset - x0Reset) / 24) * 1200,
+    Fit: {
+      path: verticalTransform(
+        SVGPath(rescaledPath).translate(
+          -offsetX + fitHorizontalPadding,
+          -offsetY,
+        ),
+      ),
+      horizAdvX: fitHorizAdvX,
+    },
+    Code: {
+      path: verticalTransform(
+        SVGPath(rescaledPath)
+          .translate(-offsetX, -offsetY)
+          .scale(codeScale)
+          .translate(codeHorizontalPadding, codeVerticalPadding),
+      ),
+      horizAdvX: codeHorizAdvX,
+    },
   };
 };
 
@@ -93,8 +140,9 @@ const transform = (pathInstance: typeof SVGPath, style: FontStyle) => {
     case REGULAR_STYLE_NAME: {
       return { path: verticalTransform(pathInstance), horizAdvX: 1200 };
     }
-    case FIT_STYLE_NAME: {
-      return convertToAspectRatioViewbox(pathInstance);
+    case FIT_STYLE_NAME:
+    case CODE_STYLE_NAME: {
+      return convertToAspectRatioViewbox(pathInstance)[style];
     }
     default:
       throw new Error(`Invalid style: ${style}`);
@@ -136,10 +184,7 @@ const buildSimpleIconsSvgFontFile = async (style: FontStyle) => {
     glyphsContent += `<glyph glyph-name="${icon.slug}" unicode="${unicodeString}" d="${path}" horiz-adv-x="${horizAdvX}"/>`;
     usedUnicodes.push(unicodeString);
 
-    unicodeHexBySlug[icon.slug] = {
-      unicode: unicodeString,
-      hex: icon.hex,
-    };
+    unicodeHexBySlug[icon.slug] = { unicode: unicodeString, hex: icon.hex };
   }
 
   const svgFontTemplate = await fs.readFile(SVG_TEMPLATE_FILE, UTF8);
@@ -183,9 +228,9 @@ const buildSimpleIconsCssFile = (
 const buildSimpleIconsMinCssFile = (cssFileContent: string) =>
   new Promise<void>(async (resolve, reject) => {
     try {
-      const cssMinifiedFile = new CleanCSS({
-        compatibility: 'ie7',
-      }).minify(cssFileContent);
+      const cssMinifiedFile = new CleanCSS({ compatibility: 'ie7' }).minify(
+        cssFileContent,
+      );
 
       await fs.writeFile(
         path.join(DIST_DIR, OUTPUT_CSS_MIN_NAME),

--- a/scripts/templates/base.css
+++ b/scripts/templates/base.css
@@ -18,6 +18,16 @@
     url(SimpleIcons-Fit.eot) format('embedded-opentype');
 }
 
+@font-face {
+  font-family: 'Simple Icons Code';
+  src:
+    url(SimpleIcons-Code.woff) format('woff'),
+    url(SimpleIcons-Code.woff2) format('woff2'),
+    url(SimpleIcons-Code.ttf) format('truetype'),
+    url(SimpleIcons-Code.otf) format('opentype'),
+    url(SimpleIcons-Code.eot) format('embedded-opentype');
+}
+
 .si {
   font-style: normal;
   font-family: 'Simple Icons', sans-serif;
@@ -27,5 +37,11 @@
 .si-fit {
   font-style: normal;
   font-family: 'Simple Icons Fit', sans-serif;
+  vertical-align: middle;
+}
+
+.si-code {
+  font-style: normal;
+  font-family: 'Simple Icons Code', sans-serif;
   vertical-align: middle;
 }

--- a/scripts/types.ts
+++ b/scripts/types.ts
@@ -1,3 +1,3 @@
-export type FontStyle = 'Regular' | 'Fit';
+export type FontStyle = 'Regular' | 'Fit' | 'Code';
 
 export type UnicodeHexBySlug = Record<string, { unicode: string; hex: string }>;


### PR DESCRIPTION
I've added a new style `Code` that makes all icon characters monospaced. This is good for use in the code editor and terminal.

I also removed the icon div's margin, padding, and border so we can more easily visualize the monospace behavior.

Next step, I will expose the font spec parameters to allow developers to customize its baseline, ascent, descent, etc.